### PR TITLE
Fixed input label displaying in precall dialog

### DIFF
--- a/src/components/precalldialog/PrecallDialog.tsx
+++ b/src/components/precalldialog/PrecallDialog.tsx
@@ -19,9 +19,10 @@ interface PrecallDialogProps {
 	actions?: ReactNode;
 }
 
-// eslint-disable-next-line
 const StyledDialogContent = styled(DialogContent)(({ theme }) => ({
-	paddingTop: '10px !important'
+	'&.MuiDialogContent-root': {
+		padding: theme.spacing(1, 3, 2.5, 3)
+	}
 }));
 
 const PrecallDialog = ({

--- a/src/components/precalldialog/PrecallDialog.tsx
+++ b/src/components/precalldialog/PrecallDialog.tsx
@@ -19,6 +19,7 @@ interface PrecallDialogProps {
 	actions?: ReactNode;
 }
 
+// eslint-disable-next-line
 const StyledDialogContent = styled(DialogContent)(({ theme }) => ({
 	paddingTop: '10px !important'
 }));

--- a/src/components/precalldialog/PrecallDialog.tsx
+++ b/src/components/precalldialog/PrecallDialog.tsx
@@ -4,6 +4,7 @@ import {
 	DialogContent,
 	DialogTitle,
 	Grid,
+	styled,
 	Typography,
 	useTheme
 } from '@mui/material';
@@ -17,6 +18,10 @@ interface PrecallDialogProps {
 	content?: ReactNode;
 	actions?: ReactNode;
 }
+
+const StyledDialogContent = styled(DialogContent)(({ theme }) => ({
+	paddingTop: '10px !important'
+}));
 
 const PrecallDialog = ({
 	content,
@@ -68,9 +73,9 @@ const PrecallDialog = ({
 					</Grid>
 				</Grid>
 			</DialogTitle>
-			<DialogContent>
+			<StyledDialogContent>
 				{ content }
-			</DialogContent>
+			</StyledDialogContent>
 			<DialogActions>
 				<Grid
 					container


### PR DESCRIPTION
I fixed a GUI problem in the precall dialog. You can see here the difference:

**Before:**

<div align="center">
<img src="https://user-images.githubusercontent.com/35871747/186699467-ebf6e6c2-7bf6-4f23-98e2-2788021165a1.jpg" alt="before" width="512px">
</div>

**After:**

<div align="center">
<img src="https://user-images.githubusercontent.com/35871747/186699525-8f1fdbac-c62d-4537-b11f-4232df813adf.jpg" alt="after" width="512px">
</div>

In order to solve this problem, I changed the style of DialogContainer of PrecallDialog component as you can see into the changed code.

