### PR TITLE
Integrate observertc

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@jitsi/rtcstats": "github:jitsi/rtcstats",
 		"@mui/icons-material": "^5.4.2",
 		"@mui/material": "^5.4.3",
-		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe",
+		"@observertc/client-monitor-js": "1.3.0",
 		"@reduxjs/toolkit": "^1.5.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@jitsi/rtcstats": "github:jitsi/rtcstats",
 		"@mui/icons-material": "^5.4.2",
 		"@mui/material": "^5.4.3",
-		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe",
+		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218",
 		"@reduxjs/toolkit": "^1.5.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@jitsi/rtcstats": "github:jitsi/rtcstats",
 		"@mui/icons-material": "^5.4.2",
 		"@mui/material": "^5.4.3",
-		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17",
+		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe",
 		"@reduxjs/toolkit": "^1.5.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"@jitsi/rtcstats": "github:jitsi/rtcstats",
 		"@mui/icons-material": "^5.4.2",
 		"@mui/material": "^5.4.3",
+		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe",
 		"@reduxjs/toolkit": "^1.5.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@jitsi/rtcstats": "github:jitsi/rtcstats",
 		"@mui/icons-material": "^5.4.2",
 		"@mui/material": "^5.4.3",
-		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218",
+		"@observertc/client-monitor-js": "1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17",
 		"@reduxjs/toolkit": "^1.5.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^13.3.0",

--- a/public/config/config.example.js
+++ b/public/config/config.example.js
@@ -193,5 +193,12 @@ var config = {
 		peerShadow: '1px 5px 0px rgba(0, 0, 0, 0.2), 0px 2px 2px 0px rgba(0, 0, 0, 0.14), 0px 3px 1px -2px rgba(0, 0, 0, 0.12)',
 		peerAvatar: 'images/buddy.svg',
 		chatColor: 'rgba(224, 224, 224, 0.52)',
+	},
+
+	// Configuration for ObserveRTC
+	// https://github.com/ObserveRTC/client-monitor-js#configurations
+	observertc: {
+		collectingPeriodInMs: 2000,
+		statsExpirationTimeInMs: 60000,
 	}
 };

--- a/src/components/me/Me.tsx
+++ b/src/components/me/Me.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useAppSelector } from '../../store/hooks';
 import { meProducersSelector } from '../../store/selectors';
 import MicButton from '../controlbuttons/MicButton';
@@ -6,6 +7,7 @@ import StopProducerButton from '../controlbuttons/StopProducerButton';
 import WebcamButton from '../controlbuttons/WebcamButton';
 import DisplayName from '../displayname/DisplayName';
 import MediaControls from '../mediacontrols/MediaControls';
+import PeerStatsView from '../peerstatsview/PeerStatsView';
 import UnmuteAlert from '../unmutealert/UnmuteAlert';
 import VideoBox from '../videobox/VideoBox';
 import VideoView from '../videoview/VideoView';
@@ -35,7 +37,8 @@ const Me = ({
 	const activeSpeaker =
 		useAppSelector((state) => state.me.id === state.room.activeSpeakerId);
 	const browser = useAppSelector((state) => state.me.browser);
-
+	const showStats = useAppSelector((state) => state.ui.showStats);
+	
 	return (
 		<>
 			<VideoBox
@@ -71,6 +74,7 @@ const Me = ({
 					mirrored={mirroredSelfView}
 					producer={webcamProducer}
 				/> }
+				{showStats && <PeerStatsView producerId={webcamProducer?.id}/>}
 			</VideoBox>
 			{ screenProducer && (
 				<VideoBox
@@ -94,6 +98,7 @@ const Me = ({
 						</MediaControls>
 					)}
 					<VideoView producer={screenProducer} contain />
+					{showStats && <PeerStatsView producerId={screenProducer.id}/>}
 				</VideoBox>
 			)}
 			{ extraVideoProducers.map((producer) => (
@@ -117,6 +122,7 @@ const Me = ({
 							producerId={producer.id}
 						/>
 					</MediaControls>
+					{showStats && <PeerStatsView producerId={producer?.id}/>}
 					<VideoView producer={producer} />
 				</VideoBox>
 			)) }

--- a/src/components/peer/Peer.tsx
+++ b/src/components/peer/Peer.tsx
@@ -8,6 +8,7 @@ import PeerActionsButton from '../controlbuttons/PeerActionsButton';
 import WindowedVideoButton from '../controlbuttons/WindowedVideoButton';
 import DisplayName from '../displayname/DisplayName';
 import MediaControls from '../mediacontrols/MediaControls';
+import PeerStatsView from '../peerstatsview/PeerStatsView';
 import PeerTranscription from '../peertranscription/PeerTranscription';
 import VideoBox from '../videobox/VideoBox';
 import VideoView from '../videoview/VideoView';
@@ -35,6 +36,7 @@ const Peer = ({
 	const peer = usePeer(id);
 	const activeSpeaker = useAppSelector((state) => id === state.room.activeSpeakerId);
 	const showParticipant = !hideNonVideo || (hideNonVideo && webcamConsumer);
+	const showStats = useAppSelector((state) => state.ui.showStats);
 
 	return (
 		<>
@@ -69,6 +71,7 @@ const Peer = ({
 					{ webcamConsumer && <VideoView
 						consumer={webcamConsumer}
 					/> }
+					{webcamConsumer && showStats && <PeerStatsView consumerId={webcamConsumer.id}/>}
 				</VideoBox>
 			)}
 			
@@ -89,6 +92,7 @@ const Peer = ({
 						<WindowedVideoButton consumerId={screenConsumer.id} />
 					</MediaControls>
 					<VideoView consumer={screenConsumer} contain />
+					{showStats && <PeerStatsView consumerId={screenConsumer.id}/>}
 				</VideoBox>
 			)}
 			{ extraVideoConsumers?.map((consumer) => (
@@ -109,6 +113,7 @@ const Peer = ({
 						<WindowedVideoButton consumerId={consumer.id} />
 					</MediaControls>
 					<VideoView consumer={consumer} />
+					{showStats && <PeerStatsView consumerId={consumer.id}/>}
 				</VideoBox>
 			)) }
 		</>

--- a/src/components/peerstatsview/PeerStatsView.tsx
+++ b/src/components/peerstatsview/PeerStatsView.tsx
@@ -1,0 +1,203 @@
+import { InboundTrackEntry, OutboundTrackEntry } from '@observertc/client-monitor-js/lib/entries/StatsEntryInterfaces';
+import { StatsCollectedListener } from '@observertc/client-monitor-js/lib/EventsRelayer';
+import { useEffect, useState } from 'react';
+import { useContext } from 'react';
+import { ServiceContext } from '../../store/store';
+import Stats from './Stats';
+
+interface PeerStatsViewProps {
+	producerId?: string;
+	consumerId?: string;
+}
+
+type InboundStats = {
+	ssrc: number;
+	receivedKbps?: number;
+	fractionLoss?: number;
+}
+
+type OutboundStats = {
+	ssrc: number;
+	sendingKbps?: number;
+	RTT?: number;
+	Fps?: number;
+}
+
+function createOutboundStats(trackStats: OutboundTrackEntry): OutboundStats[] {
+	const result: OutboundStats[] = [];
+					
+	for (const outboundRtpEntry of trackStats.outboundRtps()) {
+		const remoteInboundRtpEntry = outboundRtpEntry.getRemoteInboundRtp();
+		const stats = outboundRtpEntry.stats;
+		const { bytesSent, timestamp } = outboundRtpEntry.appData?.traces || {};
+		const now = Date.now();
+		const elapsedTimeInMs = now - (timestamp ?? 0);
+		const dBytesSent = (stats.bytesSent ?? 0) - (bytesSent ?? 0);
+		const item: OutboundStats = {
+			ssrc: stats.ssrc,
+			sendingKbps: Math.floor(dBytesSent / (elapsedTimeInMs / 125)),
+			Fps: stats.framesPerSecond,
+			RTT: (remoteInboundRtpEntry?.stats.roundTripTime ?? 0) * 1000,
+		};
+		
+		result.push(item);
+
+		outboundRtpEntry.appData.traces = {
+			bytesSent: stats.bytesSent,
+			timestamp: now,
+		};
+	}
+
+	return result;
+}
+
+function createInboundStats(trackStats: InboundTrackEntry): InboundStats[] {
+	const result: InboundStats[] = [];
+
+	for (const inboundRtpEntry of trackStats.inboundRtps()) {
+		// inboundRtpStats.stats
+		const stats = inboundRtpEntry.stats;
+		const { 
+			packetsLost, 
+			packetsReceived, 
+			bytesReceived, 
+			timestamp } = inboundRtpEntry.appData?.traces || {};
+		const now = Date.now();
+		const elapsedTimeInMs = now - (timestamp ?? 0);
+		const dBytesReceived = (stats.bytesReceived ?? 0) - (bytesReceived ?? 0);
+		const dPacketsLost = (stats.packetsLost ?? 0) - (packetsLost ?? 0);
+		const dPacketsReceived = (stats.packetsReceived ?? 0) - packetsReceived;
+		const item: InboundStats = {
+			ssrc: stats.ssrc,
+			receivedKbps: Math.floor(dBytesReceived / (elapsedTimeInMs / 125)),
+			fractionLoss: Math.round(
+				(dPacketsLost / (dPacketsLost + dPacketsReceived)) * 100
+			) / 100
+		};
+
+		result.push(item);
+
+		inboundRtpEntry.appData.traces = {
+			packetsLost: stats.packetsLost,
+			packetsReceived: stats.packetsReceived,
+			bytesReceived: stats.bytesReceived,
+			timestamp: now,
+		};
+	}
+
+	return result;
+}
+
+const PeerStatsView = ({
+	producerId,
+	consumerId,
+}: PeerStatsViewProps): JSX.Element => {
+	const { mediaService } = useContext(ServiceContext);
+	const [ inboundStats, setInboundStats ] = useState<InboundStats [ ] >([ ]);
+	const [ outboundStats, setOutboundStats ] = useState<OutboundStats [ ] >([ ]);
+
+	useEffect(() => {
+		// this runs on mount
+		const monitor = mediaService.getMonitor();
+		let listener: StatsCollectedListener | undefined;
+		
+		if (!monitor) {
+			return;
+		}
+		if (!producerId && !consumerId) {
+			return;
+		} else if (producerId && consumerId) {
+			return;
+		}
+
+		const storage = monitor.storage;
+		
+		if (producerId) {
+			const producer = mediaService.getProducer(producerId);
+			
+			if (producer) {
+				listener = () => {
+					const trackId = producer.track?.id;
+
+					if (!trackId) {
+						return;
+					}
+					const trackStats = storage.getOutboundTrack(trackId);
+
+					if (!trackStats) {
+						return;
+					}
+					
+					const newOutboundStats = createOutboundStats(trackStats);
+
+					setOutboundStats(newOutboundStats);
+				};
+			}
+		} else if (consumerId) {
+			const consumer = mediaService.getConsumer(consumerId);
+
+			if (consumer) {
+				listener = () => {
+					const trackId = consumer.track?.id;
+
+					if (!trackId) {
+						return;
+					}
+					const trackStats = storage.getInboundTrack(trackId);
+
+					if (!trackStats) {
+						return;
+					}
+
+					const newInboundStats = createInboundStats(trackStats);
+					
+					setInboundStats(newInboundStats);
+				};
+			}
+		}
+		if (listener) {
+			monitor.events.onStatsCollected(listener);
+		}
+
+		return () => {
+			if (!monitor) {
+				return;
+			}
+			if (listener) {
+				monitor.events.offStatsCollected(listener);
+			}
+		};
+	}, []);
+	let index = 0;
+
+	return (
+		<Stats
+			orientation='vertical'
+			horizontalPlacement='left'
+			verticalPlacement='bottom'
+		>
+			{inboundStats.map((stats) => {
+				return (
+					<div key={++index}>
+						<b key={++index}>SSRC: {stats.ssrc}</b><br />
+						<span key={++index}>receiving: {stats.receivedKbps ?? -1} kbps</span><br />
+						<span key={++index}>FractionLoss: {stats.fractionLoss ?? -1}</span><br />
+					</div>
+				);
+			})}
+			{outboundStats.map((stats) => {
+				return (
+					<div key={++index}>
+						<b key={++index}>SSRC: {stats.ssrc}</b><br />
+						<span key={++index}>sending: {stats.sendingKbps ?? -1} kbps</span><br />
+						<span key={++index}>RTT: {stats.RTT ?? -1} ms</span><br />
+						<span key={++index}>Fps: {stats.Fps ?? -1}</span><br />
+						<br />
+						
+					</div>
+				);
+			})}
+		</Stats>);
+};
+
+export default PeerStatsView;

--- a/src/components/peerstatsview/Stats.tsx
+++ b/src/components/peerstatsview/Stats.tsx
@@ -1,0 +1,103 @@
+import { ReactNode } from 'react';
+import { styled } from '@mui/material/styles';
+
+interface StatsDivProps {
+	flexdirection: 'row' | 'column';
+	alignitems: string;
+	justifycontent: string;
+	position: 'absolute' | 'relative';
+	withgap: number;
+	withpadding: number;
+	autohide: number;
+}
+
+const StatsDiv = styled('div')<StatsDivProps>(({
+	theme,
+	flexdirection,
+	alignitems,
+	justifycontent,
+	position,
+	withgap: withGap,
+	withpadding: withPadding,
+	autohide: autoHide
+}) => ({
+	position,
+	width: '100%',
+	height: '100%',
+	display: 'flex',
+	...(withGap && {
+		gap: theme.spacing(1)
+	}),
+	...(withPadding && {
+		padding: theme.spacing(4)
+	}),
+	flexDirection: flexdirection,
+	...(autoHide && {
+		transition: 'opacity 0.25s ease',
+		'&:hover': {
+			opacity: 1
+		},
+		opacity: 0.2,
+	}),
+	fontSize: '0.8rem',
+	color: 'white',
+	alignItems: alignitems,
+	justifyContent: justifycontent,
+	zIndex: 20,
+}));
+
+interface StatsProps {
+	orientation?: 'horizontal' | 'vertical';
+	horizontalPlacement?: 'left' | 'center' | 'right';
+	verticalPlacement?: 'top' | 'center' | 'bottom';
+	position?: 'absolute' | 'relative';
+	withGap?: boolean;
+	withPadding?: boolean;
+	autoHide?: boolean;
+	children?: ReactNode;
+}
+
+const Stats = ({
+	orientation = 'vertical',
+	horizontalPlacement = 'center',
+	verticalPlacement = 'center',
+	position = 'absolute',
+	withGap = false,
+	withPadding = true,
+	autoHide = false,
+	children
+}: StatsProps): JSX.Element => {
+	let justifyContent = 'center';
+	let alignItems = 'center';
+
+	if (horizontalPlacement === 'left') {
+		orientation === 'horizontal' ?
+			justifyContent = 'flex-start' : alignItems = 'flex-start';
+	} else if (horizontalPlacement === 'right') {
+		orientation === 'horizontal' ?
+			justifyContent = 'flex-end' : alignItems = 'flex-end';
+	}
+
+	if (verticalPlacement === 'top') {
+		orientation === 'horizontal' ?
+			alignItems = 'flex-start': justifyContent = 'flex-start';
+	} else if (verticalPlacement === 'bottom') {
+		orientation === 'horizontal' ?
+			alignItems = 'flex-end' : justifyContent = 'flex-end';
+	}
+
+	return (
+		<StatsDiv
+			flexdirection={orientation === 'horizontal' ? 'row' : 'column'}
+			position={position}
+			alignitems={alignItems}
+			justifycontent={justifyContent}
+			withgap={withGap ? 1 : 0}
+			withpadding={withPadding ? 1 : 0}
+			autohide={autoHide ? 1 : 0}
+			children={children}
+		/>
+	);
+};
+
+export default Stats;

--- a/src/components/videoview/VideoView.tsx
+++ b/src/components/videoview/VideoView.tsx
@@ -70,7 +70,7 @@ const VideoView = ({
 		if (!track || !videoElement.current) return;
 
 		const stream = new MediaStream();
-
+		
 		stream.addTrack(track);
 		videoElement.current.srcObject = stream;
 		videoElement.current.play().catch();

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -867,6 +867,8 @@ export class MediaService extends EventEmitter {
 		this.monitor = createClientMonitor(edumeetConfig.observertc);
 		this.monitor.collectors.collectFromMediasoupDevice(this.mediasoup);
 		logger.debug('Monitor is initialized');
+
+		
 	}
 
 	public rtcStatsInit(rtcStatsOptions?: RTCStatsOptions): void {

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -15,6 +15,8 @@ import rtcstatsInit from '@jitsi/rtcstats/rtcstats';
 import traceInit from '@jitsi/rtcstats/trace-ws';
 import { RTCStatsMetaData, RTCStatsOptions } from '../utils/types';
 import { Logger } from 'edumeet-common';
+import { ClientMonitor, createClientMonitor } from '@observertc/client-monitor-js';
+import edumeetConfig from '../utils/edumeetConfig';
 
 const logger = new Logger('MediaService');
 
@@ -97,6 +99,7 @@ export class MediaService extends EventEmitter {
 	private peerTransports: Map<string, PeerTransport> = new Map();
 	private peers: string[] = [];
 	private p2p = true;
+	private monitor?: ClientMonitor;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	private trace: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -107,6 +110,8 @@ export class MediaService extends EventEmitter {
 		super();
 
 		this.signalingService = signalingService;
+		this.initMonitor();
+		window.mediaService = this;
 	}
 
 	public init(): void {
@@ -132,6 +137,7 @@ export class MediaService extends EventEmitter {
 		}
 
 		this.tracks.clear();
+		this.monitor?.close();
 	}
 
 	public getConsumer(consumerId: string): Consumer | undefined {
@@ -152,6 +158,10 @@ export class MediaService extends EventEmitter {
 
 	public getTrack(trackId: string): MediaStreamTrack | undefined {
 		return this.tracks.get(trackId);
+	}
+
+	public getMonitor(): ClientMonitor | undefined {
+		return this.monitor;
 	}
 
 	public addTrack(track: MediaStreamTrack): void {
@@ -849,6 +859,15 @@ export class MediaService extends EventEmitter {
 
 	private rtcStatsCloseCallback() {
 		logger.debug('rtcStatsCloseCallback()');
+	}
+
+	public initMonitor(): void {
+		if (!edumeetConfig.observertc) {
+			return;
+		}
+		this.monitor = createClientMonitor(edumeetConfig.observertc);
+		this.monitor.collectors.collectFromMediasoupDevice(this.mediasoup);
+		logger.debug('Monitor is initialized');
 	}
 
 	public rtcStatsInit(rtcStatsOptions?: RTCStatsOptions): void {

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -866,8 +866,8 @@ export class MediaService extends EventEmitter {
 		}
 		this.monitor = createClientMonitor(edumeetConfig.observertc);
 		this.monitor.collectors.addMediasoupDevice(this.mediasoup);
-		this.monitor.events.onStatsCollected(statsEntries => {
-			logger.debug(`initMonitor(): The latest stats entries [statsEntries: %o]`, statsEntries);
+		this.monitor.events.onStatsCollected((statsEntries) => {
+			logger.debug('initMonitor(): The latest stats entries [statsEntries: %o]', statsEntries);
 		});
 		logger.debug('Monitor is initialized');
 		

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -864,6 +864,7 @@ export class MediaService extends EventEmitter {
 		if (!edumeetConfig.observertc) {
 			return;
 		}
+
 		this.monitor = createClientMonitor(edumeetConfig.observertc);
 		this.monitor.collectors.addMediasoupDevice(this.mediasoup);
 		this.monitor.events.onStatsCollected((statsEntries) => {

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -866,7 +866,9 @@ export class MediaService extends EventEmitter {
 		}
 		this.monitor = createClientMonitor(edumeetConfig.observertc);
 		this.monitor.collectors.addMediasoupDevice(this.mediasoup);
-
+		this.monitor.events.onStatsCollected(statsEntries => {
+			logger.debug(`initMonitor(): The latest stats entries [statsEntries: %o]`, statsEntries);
+		});
 		logger.debug('Monitor is initialized');
 		
 	}

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -865,9 +865,9 @@ export class MediaService extends EventEmitter {
 			return;
 		}
 		this.monitor = createClientMonitor(edumeetConfig.observertc);
-		this.monitor.collectors.collectFromMediasoupDevice(this.mediasoup);
-		logger.debug('Monitor is initialized');
+		this.monitor.collectors.addMediasoupDevice(this.mediasoup);
 
+		logger.debug('Monitor is initialized');
 		
 	}
 

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -111,7 +111,6 @@ export class MediaService extends EventEmitter {
 
 		this.signalingService = signalingService;
 		this.initMonitor();
-		window.mediaService = this;
 	}
 
 	public init(): void {

--- a/src/store/actions/startActions.tsx
+++ b/src/store/actions/startActions.tsx
@@ -199,6 +199,14 @@ export const startListeners = (): AppThunk<Promise<void>> => async (
 				break;
 			}
 
+			case 'q': {
+				const showStats = getState().ui.showStats;
+
+				dispatch(uiActions.setUi({ showStats: !showStats }));
+				
+				break;
+			}
+
 			case ' ': {
 				const audioInProgress = getState().me.audioInProgress;
 

--- a/src/store/middlewares/roomMiddleware.tsx
+++ b/src/store/middlewares/roomMiddleware.tsx
@@ -54,15 +54,14 @@ const createRoomMiddleware = ({
 									);
 									dispatch(webrtcActions.setIceServers(turnServers));
 									dispatch(webrtcActions.setRTCStatsOptions(rtcStatsOptions));
-									// dispatch(webrtcActions.setClientMonitorConfig(clientMonitorConfig));
 									dispatch(roomActions.setState('joined'));
 									dispatch(joinRoom());
-
+								});
+								if (clientMonitorSenderConfig) {
 									const roomId = getState().room.name;
-									
 									mediaService.getMonitor()?.setRoomId(roomId);
 									mediaService.getMonitor()?.connect(clientMonitorSenderConfig);
-								});
+								}
 								break;
 							}
 

--- a/src/store/middlewares/roomMiddleware.tsx
+++ b/src/store/middlewares/roomMiddleware.tsx
@@ -59,6 +59,7 @@ const createRoomMiddleware = ({
 								});
 								if (clientMonitorSenderConfig) {
 									const roomId = getState().room.name;
+
 									mediaService.getMonitor()?.setRoomId(roomId);
 									mediaService.getMonitor()?.connect(clientMonitorSenderConfig);
 								}

--- a/src/store/middlewares/roomMiddleware.tsx
+++ b/src/store/middlewares/roomMiddleware.tsx
@@ -40,7 +40,8 @@ const createRoomMiddleware = ({
 									userRoles,
 									allowWhenRoleMissing,
 									turnServers,
-									rtcStatsOptions
+									rtcStatsOptions,
+									clientMonitorSenderConfig,
 								} = notification.data;
 
 								batch(() => {
@@ -53,8 +54,14 @@ const createRoomMiddleware = ({
 									);
 									dispatch(webrtcActions.setIceServers(turnServers));
 									dispatch(webrtcActions.setRTCStatsOptions(rtcStatsOptions));
+									// dispatch(webrtcActions.setClientMonitorConfig(clientMonitorConfig));
 									dispatch(roomActions.setState('joined'));
 									dispatch(joinRoom());
+
+									const roomId = getState().room.name;
+									
+									mediaService.getMonitor()?.setRoomId(roomId);
+									mediaService.getMonitor()?.connect(clientMonitorSenderConfig);
 								});
 								break;
 							}

--- a/src/store/slices/uiSlice.tsx
+++ b/src/store/slices/uiSlice.tsx
@@ -15,11 +15,13 @@ export interface UiState {
 	lobbyDialogOpen: boolean;
 	extraVideoDialogOpen: boolean;
 	currentSettingsTab: SettingsTab;
+	showStats: boolean;
 }
 
 type UiUpdate = Partial<Omit<UiState, 'currentSettingsTab'>>;
 
 const initialState: UiState = {
+	showStats: false,
 	drawerWindow: false,
 	settingsOpen: false,
 	filesharingOpen: false,

--- a/src/store/slices/webrtcSlice.tsx
+++ b/src/store/slices/webrtcSlice.tsx
@@ -1,3 +1,4 @@
+import { ClientMonitorConfig } from '@observertc/client-monitor-js';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RtpCapabilities } from 'mediasoup-client/lib/RtpParameters';
 import { RTCStatsOptions } from '../../utils/types';
@@ -6,6 +7,7 @@ import { roomActions } from './roomSlice';
 export interface WebrtcState {
 	iceServers?: RTCIceServer[];
 	rtcStatsOptions?: RTCStatsOptions;
+	clientMonitorConfig?: ClientMonitorConfig;
 	rtpCapabilities?: RtpCapabilities;
 	torrentSupport: boolean;
 	tracker?: string;
@@ -36,6 +38,9 @@ const webrtcSlice = createSlice({
 		}),
 		setRTCStatsOptions: ((state, action: PayloadAction<RTCStatsOptions>) => {
 			state.rtcStatsOptions = action.payload;
+		}),
+		setClientMonitorConfig: ((state, action: PayloadAction<ClientMonitorConfig>) => {
+			state.clientMonitorConfig = action.payload;
 		}),
 	},
 	extraReducers: (builder) => {

--- a/src/store/slices/webrtcSlice.tsx
+++ b/src/store/slices/webrtcSlice.tsx
@@ -1,4 +1,3 @@
-import { ClientMonitorConfig } from '@observertc/client-monitor-js';
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RtpCapabilities } from 'mediasoup-client/lib/RtpParameters';
 import { RTCStatsOptions } from '../../utils/types';
@@ -7,7 +6,6 @@ import { roomActions } from './roomSlice';
 export interface WebrtcState {
 	iceServers?: RTCIceServer[];
 	rtcStatsOptions?: RTCStatsOptions;
-	clientMonitorConfig?: ClientMonitorConfig;
 	rtpCapabilities?: RtpCapabilities;
 	torrentSupport: boolean;
 	tracker?: string;
@@ -38,9 +36,6 @@ const webrtcSlice = createSlice({
 		}),
 		setRTCStatsOptions: ((state, action: PayloadAction<RTCStatsOptions>) => {
 			state.rtcStatsOptions = action.payload;
-		}),
-		setClientMonitorConfig: ((state, action: PayloadAction<ClientMonitorConfig>) => {
-			state.clientMonitorConfig = action.payload;
 		}),
 	},
 	extraReducers: (builder) => {

--- a/src/utils/edumeetConfig.tsx
+++ b/src/utils/edumeetConfig.tsx
@@ -1,4 +1,3 @@
-import { MediaService } from '../services/mediaService';
 import { defaultEdumeetConfig, EdumeetConfig } from './types';
 
 declare module '@mui/material/styles' {

--- a/src/utils/edumeetConfig.tsx
+++ b/src/utils/edumeetConfig.tsx
@@ -1,3 +1,4 @@
+import { MediaService } from '../services/mediaService';
 import { defaultEdumeetConfig, EdumeetConfig } from './types';
 
 declare module '@mui/material/styles' {
@@ -35,5 +36,6 @@ declare global {
 export default {
 	...defaultEdumeetConfig,
 	...window.config,
-	theme: { ...defaultEdumeetConfig.theme, ...window.config?.theme }
+	theme: { ...defaultEdumeetConfig.theme, ...window.config?.theme },
+	observertc: { ...defaultEdumeetConfig.observertc, ...window.config?.observertc }
 };

--- a/src/utils/types.tsx
+++ b/src/utils/types.tsx
@@ -85,6 +85,7 @@ export const defaultEdumeetConfig: EdumeetConfig = {
 	},
 	observertc: {
 		collectingPeriodInMs: 5000,
+		statsExpirationTimeInMs: 60000,
 	}
 };
 
@@ -128,7 +129,7 @@ export interface EdumeetConfig {
 	supportUrl: string;
 	privacyUrl: string;
 	theme: ThemeOptions;
-	observertc?: ClientMonitorConfig;
+	observertc: ClientMonitorConfig;
 }
 
 export type RoomLayout = 'filmstrip' | 'democratic';

--- a/src/utils/types.tsx
+++ b/src/utils/types.tsx
@@ -1,4 +1,5 @@
 import { ThemeOptions } from '@mui/material';
+import { ClientMonitorConfig } from '@observertc/client-monitor-js';
 
 export const defaultEdumeetConfig: EdumeetConfig = {
 	loginEnabled: false,
@@ -81,6 +82,9 @@ export const defaultEdumeetConfig: EdumeetConfig = {
 		peerShadow: 'rgba(0, 0, 0, 0.2) 0px 3px 3px -2px, rgba(0, 0, 0, 0.14) 0px 3px 4px 0px, rgba(0, 0, 0, 0.12) 0px 1px 8px 0px',
 		peerAvatar: 'images/buddy.svg',
 		chatColor: 'rgba(224, 224, 224, 0.52)'
+	},
+	observertc: {
+		collectingPeriodInMs: 5000,
 	}
 };
 
@@ -124,6 +128,7 @@ export interface EdumeetConfig {
 	supportUrl: string;
 	privacyUrl: string;
 	theme: ThemeOptions;
+	observertc?: ClientMonitorConfig;
 }
 
 export type RoomLayout = 'filmstrip' | 'democratic';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,10 +1725,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@observertc/client-monitor-js@1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe":
-  version "1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe"
-  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe.tgz#d753c2c61e4e1f1074091edb4a56de2b9772ef92"
-  integrity sha512-JXMkb8tkZxUAlhhQwd95r9bF2MJixZGQsu6OKwk9s01axsjR13AGdn17o+i5SzWW4PotgakwbDayZcae7vmPEg==
+"@observertc/client-monitor-js@1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218":
+  version "1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218"
+  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218.tgz#d464683a8351c0f5a1447805b09b92a75494dea2"
+  integrity sha512-hV0eqsTKuyK9hLOVYiO91YFWHsSpS7efdv/wCR7QL3EU+PZEnEi0LCi1vqvwYjWtsiqOfs39y3Ob7dLIl3Ky6w==
   dependencies:
     "@observertc/monitor-schemas" "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
     "@types/events" "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,10 +1725,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@observertc/client-monitor-js@1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17":
-  version "1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17"
-  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17.tgz#75daaa4d244a6727bba02fff4356380762c085f4"
-  integrity sha512-S5p/s7mkk8xaOED14uDqpfzxGTCyHhbUzGHtkZG5HXY/uVmpKnM1GvctFQ48uiD0KHXJOrt+F0qWeAs+NIY9Gw==
+"@observertc/client-monitor-js@1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe":
+  version "1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe"
+  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe.tgz#e599d731f6a7367e6dc46ec6dc56851da1cdacea"
+  integrity sha512-plvbtJuVQaoiVDyEGksRNyQkLWkDpyylnKMiE1KYJTfIC4GzJQ8ygv3roYvIMvjD9PgdTmcQ+Ws78LnbDBZjkg==
   dependencies:
     "@observertc/monitor-schemas" "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
     "@types/events" "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,6 +1725,27 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@observertc/client-monitor-js@1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe":
+  version "1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe"
+  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.ed5e446ef3ca6ad72f212ce096186aea23c71dfe.tgz#d753c2c61e4e1f1074091edb4a56de2b9772ef92"
+  integrity sha512-JXMkb8tkZxUAlhhQwd95r9bF2MJixZGQsu6OKwk9s01axsjR13AGdn17o+i5SzWW4PotgakwbDayZcae7vmPEg==
+  dependencies:
+    "@observertc/monitor-schemas" "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
+    "@types/events" "^3.0.0"
+    "@types/protobufjs" "^6.0.0"
+    "@types/uuid" "^8.3.4"
+    bowser "^2.11.0"
+    js-base64 "^3.7.2"
+    js-sha256 "^0.9.0"
+    loglevel "^1.8.0"
+    protobufjs "^6.11.3"
+    uuid "^8.3.2"
+
+"@observertc/monitor-schemas@2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78":
+  version "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
+  resolved "https://registry.yarnpkg.com/@observertc/monitor-schemas/-/monitor-schemas-2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78.tgz#ea3671dd7adfe5925a210661cca9cf0cf44580c7"
+  integrity sha512-XSD/w3O3xTW6YW0lFvRPIQlhZvqmFBcEF3NJDkNM8/w1QrlBm77ZmDVs5kVxm8MbYL/zFeYHn32eUgLsiKIm8g==
+
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.4.3.tgz#1eec460596d200c0236bf195b078a5d1df89b766"
@@ -1741,6 +1762,59 @@
   version "2.11.5"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.5.tgz#db5a11bf66bdab39569719555b0f76e138d7bd64"
   integrity sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
 "@reduxjs/toolkit@^1.5.1":
   version "1.8.2"
@@ -2132,6 +2206,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/long@^4.0.1":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
 "@types/magnet-uri@*":
   version "5.1.3"
   resolved "https://registry.yarnpkg.com/@types/magnet-uri/-/magnet-uri-5.1.3.tgz#cdf974721012bd758c0f559cabcad7bab87f9008"
@@ -2158,6 +2237,11 @@
   version "18.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.0.0.tgz#67c7b724e1bcdd7a8821ce0d5ee184d3b4dd525a"
   integrity sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==
+
+"@types/node@>=13.7.0":
+  version "18.11.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.7.tgz#8ccef136f240770c1379d50100796a6952f01f94"
+  integrity sha512-LhFTglglr63mNXUSRYD8A+ZAIu5sFqNJ4Y2fPuY7UlrySJH87rRRlhtVmMHplmfk5WkoJGmDjE9oiTfyX94CpQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2194,6 +2278,13 @@
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
+"@types/protobufjs@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/protobufjs/-/protobufjs-6.0.0.tgz#aeabb43f9507bb19c8adfb479584c151082353e4"
+  integrity sha512-A27RDExpAf3rdDjIrHKiJK6x8kqqJ4CmoChwtipfhVAn1p7+wviQFFP7dppn8FslSbHtQeVPvi8wNKkDjSYjHw==
+  dependencies:
+    protobufjs "*"
 
 "@types/q@^1.5.1":
   version "1.5.5"
@@ -7932,10 +8023,20 @@ jest@26.6.0:
     import-local "^3.0.2"
     jest-cli "^26.6.0"
 
+js-base64@^3.7.2:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.2.tgz#816d11d81a8aff241603d19ce5761e13e41d7745"
+  integrity sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ==
+
 js-md5@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.7.3.tgz#b4f2fbb0b327455f598d6727e38ec272cd09c3f2"
   integrity sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==
+
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -8305,10 +8406,20 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loglevel@^1.6.8:
+loglevel@^1.6.8, loglevel@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.0.tgz#e7ec73a57e1e7b419cb6c6ac06bf050b67356114"
   integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
+
+long@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.0.tgz#2696dadf4b4da2ce3f6f6b89186085d94d52fd61"
+  integrity sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -10313,6 +10424,43 @@ prop-types@^15.5.7, prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
+
+protobufjs@*:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.1.2.tgz#a0cf6aeaf82f5625bffcf5a38b7cd2a7de05890c"
+  integrity sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
+protobufjs@^6.11.3:
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
+  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
 
 proxy-addr@~2.0.7:
   version "2.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,10 +1725,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@observertc/client-monitor-js@1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe":
-  version "1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe"
-  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.58af8828cad0351295eba175731a8b62b53072fe.tgz#e599d731f6a7367e6dc46ec6dc56851da1cdacea"
-  integrity sha512-plvbtJuVQaoiVDyEGksRNyQkLWkDpyylnKMiE1KYJTfIC4GzJQ8ygv3roYvIMvjD9PgdTmcQ+Ws78LnbDBZjkg==
+"@observertc/client-monitor-js@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0.tgz#94ad96a2df7a03bb7e7719bfcc56474de420d029"
+  integrity sha512-4LK6MvQx/hkbCJyW1MSsI/o8i1HcpMZym9fZZ32RQhVabn2XRuy3qONDv61bVIF5c6DVom9DBeJrI9/xeQlC/w==
   dependencies:
     "@observertc/monitor-schemas" "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
     "@types/events" "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,10 +1725,10 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@observertc/client-monitor-js@1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218":
-  version "1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218"
-  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.7ea9b89e5a64bead0af52308e4cc17e007d77218.tgz#d464683a8351c0f5a1447805b09b92a75494dea2"
-  integrity sha512-hV0eqsTKuyK9hLOVYiO91YFWHsSpS7efdv/wCR7QL3EU+PZEnEi0LCi1vqvwYjWtsiqOfs39y3Ob7dLIl3Ky6w==
+"@observertc/client-monitor-js@1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17":
+  version "1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17"
+  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0-SNAPSHOT.050ba8bcc0847d1368a3f3491778a1435fa7fe17.tgz#75daaa4d244a6727bba02fff4356380762c085f4"
+  integrity sha512-S5p/s7mkk8xaOED14uDqpfzxGTCyHhbUzGHtkZG5HXY/uVmpKnM1GvctFQ48uiD0KHXJOrt+F0qWeAs+NIY9Gw==
   dependencies:
     "@observertc/monitor-schemas" "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
     "@types/events" "^3.0.0"


### PR DESCRIPTION
Integrate ObserveRTC client-monitor-js to edumeet for monitoring WebRTC stacks.

This PR add client-monitor-js and integrate it with mediasoup.
client-monitor-js automatically keep track of producers and consumers and their corresponding tracks, providing up to date stats polled from mediasoup transports.

Local monitoring usage is also added as an example here in PeerStatsView, in which component monitoring storage is used.

The room-server sending roomJoined event can contain data command the monitor to connect to an observer.