### PR TITLE
Fixed labels design for device chooser input field

### DIFF
--- a/src/components/devicechooser/DeviceChooser.tsx
+++ b/src/components/devicechooser/DeviceChooser.tsx
@@ -1,6 +1,6 @@
 import {
 	FormControl,
-	FormHelperText,
+	InputLabel,
 	MenuItem,
 	Select,
 	styled
@@ -19,10 +19,17 @@ interface DeviceChooserProps {
 	devices: MediaDevice[];
 }
 
-export const ChooserDiv = styled('div')({
+export const ChooserDiv = styled('div')(({ theme }) => ({
 	display: 'flex',
-	flexDirection: 'row'
-});
+	flexDirection: 'row',
+	marginTop: theme.spacing(2),
+	marginBottom: theme.spacing(2)
+}));
+
+export const StyledInputLabel = styled(InputLabel)(({ theme }) => ({
+	padding: theme.spacing(0, 0.5),
+	backgroundColor: '#fff'
+}));
 
 const DeviceChooser = ({
 	value,
@@ -34,7 +41,10 @@ const DeviceChooser = ({
 	devices,
 }: DeviceChooserProps): JSX.Element => {
 	return (
-		<FormControl fullWidth>
+		<FormControl variant="outlined" fullWidth>
+			<StyledInputLabel>
+				{ devices.length ? devicesLabel : noDevicesLabel }
+			</StyledInputLabel>
 			<Select
 				value={devices.length ? (value || '') : ''}
 				onChange={(event) => {
@@ -57,9 +67,6 @@ const DeviceChooser = ({
 					);
 				})}
 			</Select>
-			<FormHelperText>
-				{ devices.length ? devicesLabel : noDevicesLabel }
-			</FormHelperText>
 		</FormControl>
 	);
 };

--- a/src/components/devicechooser/DeviceChooser.tsx
+++ b/src/components/devicechooser/DeviceChooser.tsx
@@ -22,8 +22,7 @@ interface DeviceChooserProps {
 export const ChooserDiv = styled('div')(({ theme }) => ({
 	display: 'flex',
 	flexDirection: 'row',
-	marginTop: theme.spacing(2),
-	marginBottom: theme.spacing(2)
+	margin: theme.spacing(2, 0)
 }));
 
 export const StyledInputLabel = styled(InputLabel)(({ theme }) => ({


### PR DESCRIPTION
Fixed labels position for device chooser input field. In this way, there is no more confusion about to which input field a label is referring to. See the following screenshots:

**Before:**

![immagine](https://user-images.githubusercontent.com/35871747/212632554-7880f692-65c1-478a-af22-7e93d5997d4c.png)

**After:**

![immagine](https://user-images.githubusercontent.com/35871747/212632732-774b0542-df44-4943-a0c0-ce0b253150ba.png)
