### PR TITLE
Fix for statsview and bitrate lettercase

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"@jitsi/rtcstats": "github:jitsi/rtcstats",
 		"@mui/icons-material": "^5.4.2",
 		"@mui/material": "^5.4.3",
-		"@observertc/client-monitor-js": "1.3.0",
+		"@observertc/client-monitor-js": "1.3.2",
 		"@reduxjs/toolkit": "^1.5.1",
 		"@testing-library/jest-dom": "^5.16.4",
 		"@testing-library/react": "^13.3.0",

--- a/src/components/peerstatsview/PeerStatsView.tsx
+++ b/src/components/peerstatsview/PeerStatsView.tsx
@@ -31,11 +31,11 @@ function createOutboundStats(trackStats: OutboundTrackEntry): OutboundStats[] {
 		const stats = outboundRtpEntry.stats;
 		const { bytesSent, timestamp } = outboundRtpEntry.appData?.traces || {};
 		const now = Date.now();
-		const elapsedTimeInMs = now - (timestamp ?? 0);
+		const elapsedTimeInSec = (now - (timestamp ?? 0)) / 1000;
 		const dBytesSent = (stats.bytesSent ?? 0) - (bytesSent ?? 0);
 		const item: OutboundStats = {
 			ssrc: stats.ssrc,
-			sendingKbps: Math.floor(dBytesSent / (elapsedTimeInMs / 125)),
+			sendingKbps: Math.floor(((dBytesSent * 8) / 1000) / elapsedTimeInSec),
 			Fps: stats.framesPerSecond,
 			RTT: (remoteInboundRtpEntry?.stats.roundTripTime ?? 0) * 1000,
 		};
@@ -63,13 +63,13 @@ function createInboundStats(trackStats: InboundTrackEntry): InboundStats[] {
 			bytesReceived, 
 			timestamp } = inboundRtpEntry.appData?.traces || {};
 		const now = Date.now();
-		const elapsedTimeInMs = now - (timestamp ?? 0);
+		const elapsedTimeInSec = (now - (timestamp ?? 0)) / 1000;
 		const dBytesReceived = (stats.bytesReceived ?? 0) - (bytesReceived ?? 0);
 		const dPacketsLost = (stats.packetsLost ?? 0) - (packetsLost ?? 0);
 		const dPacketsReceived = (stats.packetsReceived ?? 0) - packetsReceived;
 		const item: InboundStats = {
 			ssrc: stats.ssrc,
-			receivedKbps: Math.floor(dBytesReceived / (elapsedTimeInMs / 125)),
+			receivedKbps: Math.floor(((dBytesReceived * 8) / 1000) / elapsedTimeInSec),
 			fractionLoss: Math.round(
 				(dPacketsLost / (dPacketsLost + dPacketsReceived)) * 100
 			) / 100

--- a/src/utils/encodingsHandler.tsx
+++ b/src/utils/encodingsHandler.tsx
@@ -12,44 +12,44 @@ const VIDEO_CONSTRAINS: Record<Resolution, Record<string, number>> = {
 const SIMULCAST_PROFILES = {
 	'320': [ {
 		'scaleResolutionDownBy': 1,
-		'maxBitRate': 150000
+		'maxBitrate': 150000
 	} ],
 	'640': [ {
 		'scaleResolutionDownBy': 2,
-		'maxBitRate': 150000
+		'maxBitrate': 150000
 	}, {
 		'scaleResolutionDownBy': 1,
-		'maxBitRate': 500000
+		'maxBitrate': 500000
 	} ],
 	'1280': [ {
 		'scaleResolutionDownBy': 4,
-		'maxBitRate': 150000
+		'maxBitrate': 150000
 	}, {
 		'scaleResolutionDownBy': 2,
-		'maxBitRate': 500000
+		'maxBitrate': 500000
 	}, {
 		'scaleResolutionDownBy': 1,
-		'maxBitRate': 1200000
+		'maxBitrate': 1200000
 	} ],
 	'1920': [ {
 		'scaleResolutionDownBy': 6,
-		'maxBitRate': 150000
+		'maxBitrate': 150000
 	}, {
 		'scaleResolutionDownBy': 3,
-		'maxBitRate': 500000
+		'maxBitrate': 500000
 	}, {
 		'scaleResolutionDownBy': 1,
-		'maxBitRate': 3500000
+		'maxBitrate': 3500000
 	} ],
 	'3840': [ {
 		'scaleResolutionDownBy': 12,
-		'maxBitRate': 150000
+		'maxBitrate': 150000
 	}, {
 		'scaleResolutionDownBy': 6,
-		'maxBitRate': 500000
+		'maxBitrate': 500000
 	}, {
 		'scaleResolutionDownBy': 1,
-		'maxBitRate': 10000000
+		'maxBitrate': 10000000
 	} ]
 };
 

--- a/src/utils/types.tsx
+++ b/src/utils/types.tsx
@@ -152,7 +152,7 @@ export type Resolution = 'low' | 'medium' | 'high' | 'veryhigh' | 'ultra';
 
 export interface SimulcastProfile {
 	scaleResolutionDownBy: number;
-	maxBitRate: number;
+	maxBitrate: number;
 }
 
 export interface AudioPreset {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,26 +1725,25 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@observertc/client-monitor-js@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.0.tgz#94ad96a2df7a03bb7e7719bfcc56474de420d029"
-  integrity sha512-4LK6MvQx/hkbCJyW1MSsI/o8i1HcpMZym9fZZ32RQhVabn2XRuy3qONDv61bVIF5c6DVom9DBeJrI9/xeQlC/w==
+"@observertc/client-monitor-js@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@observertc/client-monitor-js/-/client-monitor-js-1.3.2.tgz#b21bdcf712ceed9015b81525f02cd57e2827ed81"
+  integrity sha512-om9BTWbML26qWhveytbtYpS4OtBn2tIUQPB+jlGdI5vvfxp/8we3ensf3norDtzn+22LO9DgSoCTeVJnJtbSpA==
   dependencies:
-    "@observertc/monitor-schemas" "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
+    "@observertc/monitor-schemas" "2.2.0"
     "@types/events" "^3.0.0"
     "@types/protobufjs" "^6.0.0"
     "@types/uuid" "^8.3.4"
     bowser "^2.11.0"
     js-base64 "^3.7.2"
-    js-sha256 "^0.9.0"
     loglevel "^1.8.0"
     protobufjs "^6.11.3"
     uuid "^8.3.2"
 
-"@observertc/monitor-schemas@2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78":
-  version "2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78"
-  resolved "https://registry.yarnpkg.com/@observertc/monitor-schemas/-/monitor-schemas-2.2.0-SNAPSHOT.08a432335fee953aa5ebaeb7a81b12b5d41a5d78.tgz#ea3671dd7adfe5925a210661cca9cf0cf44580c7"
-  integrity sha512-XSD/w3O3xTW6YW0lFvRPIQlhZvqmFBcEF3NJDkNM8/w1QrlBm77ZmDVs5kVxm8MbYL/zFeYHn32eUgLsiKIm8g==
+"@observertc/monitor-schemas@2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@observertc/monitor-schemas/-/monitor-schemas-2.2.0.tgz#46430d2671faf64e4c71052606fd0c96a11f5fcd"
+  integrity sha512-ZzVFjD4DLrNwgOzGFaC+5DrU6D/8GE4jXMj2gp44lA2UgbKWdD8vaPufCJu2m0dU+S37ftKbNJAycvWUO9hC4w==
 
 "@pmmmwh/react-refresh-webpack-plugin@0.4.3":
   version "0.4.3"
@@ -8032,11 +8031,6 @@ js-md5@0.7.3:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/js-md5/-/js-md5-0.7.3.tgz#b4f2fbb0b327455f598d6727e38ec272cd09c3f2"
   integrity sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==
-
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
 * Update client-monitor-js to 1.3.2
 * Change from `BitRate` to `Bitrate` in encodingsHandler to be aligned with Mediasoup RtpEncodingParameters
 * Fix wrong value issue for PeerStatsView