### PR TITLE
Fix signaling state

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,6 +22,7 @@
 		"sourceType": "module",
 		"project": "./tsconfig.json"
 	},
+	"ignorePatterns": ["**/config.js"],
 	"rules": {
 		"array-bracket-spacing": [ 2, "always", {
 			"objectsInArrays": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "edumeet-client",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"private": true,
 	"description": "The Edumeet service client",
 	"author": "Håvar Aambø Fosstveit <havar@fosstveit.net>",

--- a/src/services/signalingService.tsx
+++ b/src/services/signalingService.tsx
@@ -60,7 +60,7 @@ export class SignalingService extends EventEmitter {
 			logger.debug('connect');
 
 			if (!this.connected)
-				this.emit('connect');
+				this.emit('connected');
 
 			this.connected = true;
 		});


### PR DESCRIPTION
closes #89 

Emit correct event from `SignalingService` so `signaling.state` is updated to "connected" on successful websocket connection.