### PR TITLE
Fixed missing self-tab sharing option in sharing menu

### DIFF
--- a/src/store/actions/mediaActions.tsx
+++ b/src/store/actions/mediaActions.tsx
@@ -783,7 +783,7 @@ export const updateScreenSharing = ({
 				}));
 			}
 
-			const stream = await navigator.mediaDevices.getDisplayMedia({
+			const SHARING_CONSTRAINTS = {
 				video: {
 					...getVideoConstrains(
 						screenSharingResolution,
@@ -798,8 +798,11 @@ export const updateScreenSharing = ({
 					echoCancellation,
 					noiseSuppression,
 					sampleSize
-				}
-			});
+				},
+				selfBrowserSurface: 'include'
+			};
+
+			const stream = await navigator.mediaDevices.getDisplayMedia(SHARING_CONSTRAINTS);
 
 			([ videoTrack ] = stream.getVideoTracks());
 

--- a/src/store/middlewares/recordingMiddleware.tsx
+++ b/src/store/middlewares/recordingMiddleware.tsx
@@ -19,7 +19,8 @@ const RECORDING_CONSTRAINTS = {
 	advanced: [
 		{ width: 1920, height: 1080 },
 		{ width: 1280, height: 720 }
-	]
+	],
+	selfBrowserSurface: 'include'
 };
 
 const createRecordingMiddleware = ({


### PR DESCRIPTION
This PR solves the problem mentioned in #94. In this way it is possible to share the tab in which the screensharing request has been done.