### PR TITLE
Moved personal media controls on bottom for mobile users

### DIFF
--- a/src/components/controlbuttonsbar/ControlButtonsBar.tsx
+++ b/src/components/controlbuttonsbar/ControlButtonsBar.tsx
@@ -18,6 +18,7 @@ const ControlButtonsBar = (): JSX.Element => {
 					horizontalPlacement={ isMobile ? 'center' : 'left' }
 					verticalPlacement={ isMobile ? 'bottom' :'center' }
 					autoHide={ !isMobile }
+					mobile={ isMobile }
 				>
 					<MicButton
 						onColor='default'

--- a/src/components/controlbuttonsbar/ControlButtonsBar.tsx
+++ b/src/components/controlbuttonsbar/ControlButtonsBar.tsx
@@ -18,7 +18,6 @@ const ControlButtonsBar = (): JSX.Element => {
 					horizontalPlacement={ isMobile ? 'center' : 'left' }
 					verticalPlacement={ isMobile ? 'bottom' :'center' }
 					autoHide={ !isMobile }
-					mobile={ isMobile }
 				>
 					<MicButton
 						onColor='default'

--- a/src/components/controlbuttonsbar/ControlButtonsBar.tsx
+++ b/src/components/controlbuttonsbar/ControlButtonsBar.tsx
@@ -8,14 +8,17 @@ const ControlButtonsBar = (): JSX.Element => {
 	const controlButtonsBar =
 		useAppSelector((state) => state.settings.controlButtonsBar);
 	const hideSelfView = useAppSelector((state) => state.settings.hideSelfView);
+	const browser = useAppSelector((state) => state.me.browser);
+	const isMobile = browser.platform === 'mobile';
 
 	return (
 		<>
-			{ (hideSelfView || controlButtonsBar) &&
+			{ (hideSelfView || controlButtonsBar || isMobile) &&
 				<MediaControls
-					orientation='vertical'
-					horizontalPlacement='left'
-					verticalPlacement='center'
+					orientation={ isMobile ? 'horizontal' : 'vertical' }
+					horizontalPlacement={ isMobile ? 'center' : 'left' }
+					verticalPlacement={ isMobile ? 'bottom' :'center' }
+					autoHide={ !isMobile }
 				>
 					<MicButton
 						onColor='default'

--- a/src/components/controlbuttonsbar/ControlButtonsBar.tsx
+++ b/src/components/controlbuttonsbar/ControlButtonsBar.tsx
@@ -8,8 +8,7 @@ const ControlButtonsBar = (): JSX.Element => {
 	const controlButtonsBar =
 		useAppSelector((state) => state.settings.controlButtonsBar);
 	const hideSelfView = useAppSelector((state) => state.settings.hideSelfView);
-	const browser = useAppSelector((state) => state.me.browser);
-	const isMobile = browser.platform === 'mobile';
+	const isMobile = useAppSelector((state) => state.me.browser.platform === 'mobile');
 
 	return (
 		<>

--- a/src/components/controlbuttonsbar/ControlButtonsBar.tsx
+++ b/src/components/controlbuttonsbar/ControlButtonsBar.tsx
@@ -30,7 +30,7 @@ const ControlButtonsBar = (): JSX.Element => {
 						offColor='error'
 						disabledColor='default'
 					/>
-					<ScreenshareButton />
+					{ !isMobile && <ScreenshareButton /> }
 				</MediaControls>
 			}
 		</>

--- a/src/components/me/Me.tsx
+++ b/src/components/me/Me.tsx
@@ -50,7 +50,7 @@ const Me = ({
 				height={style.height}
 			>
 				<DisplayName disabled={false} displayName={displayName} />
-				{ !(hideSelfView || controlButtonsBar) && (
+				{ !(hideSelfView || controlButtonsBar || browser.platform === 'mobile') && (
 					<MediaControls
 						orientation='vertical'
 						horizontalPlacement='right'

--- a/src/components/me/Me.tsx
+++ b/src/components/me/Me.tsx
@@ -48,6 +48,7 @@ const Me = ({
 				margin={spacing}
 				width={style.width}
 				height={style.height}
+				zIndex={0}
 			>
 				<DisplayName disabled={false} displayName={displayName} />
 				{ !(hideSelfView || controlButtonsBar || browser.platform === 'mobile') && (

--- a/src/components/mediacontrols/MediaControls.tsx
+++ b/src/components/mediacontrols/MediaControls.tsx
@@ -42,6 +42,10 @@ const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
 	alignItems: alignitems,
 	justifyContent: justifycontent,
 	zIndex: 42,
+	pointerEvents: 'none',
+	'& > *': {
+		pointerEvents: 'auto'
+	}
 }));
 
 interface MediaControlsProps {

--- a/src/components/mediacontrols/MediaControls.tsx
+++ b/src/components/mediacontrols/MediaControls.tsx
@@ -41,7 +41,7 @@ const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
 	}),
 	alignItems: alignitems,
 	justifyContent: justifycontent,
-	zIndex: 21,
+	zIndex: 42,
 }));
 
 interface MediaControlsProps {

--- a/src/components/mediacontrols/MediaControls.tsx
+++ b/src/components/mediacontrols/MediaControls.tsx
@@ -9,6 +9,7 @@ interface MediaControlsDivProps {
 	withgap: number;
 	withpadding: number;
 	autohide: number;
+	mobile?: number;
 }
 
 const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
@@ -19,11 +20,17 @@ const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
 	position,
 	withgap: withGap,
 	withpadding: withPadding,
-	autohide: autoHide
+	autohide: autoHide,
+	mobile
 }) => ({
-	position,
+	...((mobile && {
+		position: 'absolute',
+		bottom: '0'
+	}) || (!mobile && {
+		position,
+		height: '100%'
+	})),
 	width: '100%',
-	height: '100%',
 	display: 'flex',
 	...(withGap && {
 		gap: theme.spacing(2)
@@ -52,6 +59,7 @@ interface MediaControlsProps {
 	withGap?: boolean;
 	withPadding?: boolean;
 	autoHide?: boolean;
+	mobile?: boolean;
 	children?: ReactNode;
 }
 
@@ -63,6 +71,7 @@ const MediaControls = ({
 	withGap = true,
 	withPadding = true,
 	autoHide = true,
+	mobile = false,
 	children
 }: MediaControlsProps): JSX.Element => {
 	let justifyContent = 'center';
@@ -93,6 +102,7 @@ const MediaControls = ({
 			withgap={withGap ? 1 : 0}
 			withpadding={withPadding ? 1 : 0}
 			autohide={autoHide ? 1 : 0}
+			mobile={mobile ? 1 : 0}
 			children={children}
 		/>
 	);

--- a/src/components/mediacontrols/MediaControls.tsx
+++ b/src/components/mediacontrols/MediaControls.tsx
@@ -25,12 +25,14 @@ const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
 }) => ({
 	...((mobile && {
 		position: 'absolute',
-		bottom: '0'
+		bottom: '0',
+		left: '50%',
+		transform: 'translateX(-50%)',
 	}) || (!mobile && {
 		position,
+		width: '100%',
 		height: '100%'
 	})),
-	width: '100%',
 	display: 'flex',
 	...(withGap && {
 		gap: theme.spacing(2)

--- a/src/components/mediacontrols/MediaControls.tsx
+++ b/src/components/mediacontrols/MediaControls.tsx
@@ -9,7 +9,6 @@ interface MediaControlsDivProps {
 	withgap: number;
 	withpadding: number;
 	autohide: number;
-	mobile?: number;
 }
 
 const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
@@ -20,19 +19,11 @@ const MediaControlsDiv = styled('div')<MediaControlsDivProps>(({
 	position,
 	withgap: withGap,
 	withpadding: withPadding,
-	autohide: autoHide,
-	mobile
+	autohide: autoHide
 }) => ({
-	...((mobile && {
-		position: 'absolute',
-		bottom: '0',
-		left: '50%',
-		transform: 'translateX(-50%)',
-	}) || (!mobile && {
-		position,
-		width: '100%',
-		height: '100%'
-	})),
+	position,
+	width: '100%',
+	height: '100%',
 	display: 'flex',
 	...(withGap && {
 		gap: theme.spacing(2)
@@ -61,7 +52,6 @@ interface MediaControlsProps {
 	withGap?: boolean;
 	withPadding?: boolean;
 	autoHide?: boolean;
-	mobile?: boolean;
 	children?: ReactNode;
 }
 
@@ -73,7 +63,6 @@ const MediaControls = ({
 	withGap = true,
 	withPadding = true,
 	autoHide = true,
-	mobile = false,
 	children
 }: MediaControlsProps): JSX.Element => {
 	let justifyContent = 'center';
@@ -104,7 +93,6 @@ const MediaControls = ({
 			withgap={withGap ? 1 : 0}
 			withpadding={withPadding ? 1 : 0}
 			autohide={autoHide ? 1 : 0}
-			mobile={mobile ? 1 : 0}
 			children={children}
 		/>
 	);

--- a/src/components/peer/Peer.tsx
+++ b/src/components/peer/Peer.tsx
@@ -48,6 +48,7 @@ const Peer = ({
 					margin={spacing}
 					width={style.width}
 					height={style.height}
+					zIndex={0}
 				>
 					<StateIndicators peerId={id} />
 					<DisplayName displayName={peer?.displayName} />

--- a/src/components/settingsdialog/AppearanceSettings.tsx
+++ b/src/components/settingsdialog/AppearanceSettings.tsx
@@ -21,7 +21,7 @@ const AppearanceSettings = (): JSX.Element => {
 		hideSelfView,
 		controlButtonsBar
 	} = useAppSelector((state) => state.settings);
-	const browser = useAppSelector((state) => state.me.browser);
+	const isMobile = useAppSelector((state) => state.me.browser.platform === 'mobile');
 
 	const handleChange = (
 		event: React.ChangeEvent<HTMLInputElement>,
@@ -56,7 +56,7 @@ const AppearanceSettings = (): JSX.Element => {
 					}
 					label={hideSelfViewLabel()}
 				/>
-				{ browser.platform !== 'mobile' && (
+				{ !isMobile && (
 					<FormControlLabel
 						control={
 							<Switch

--- a/src/components/settingsdialog/AppearanceSettings.tsx
+++ b/src/components/settingsdialog/AppearanceSettings.tsx
@@ -21,6 +21,7 @@ const AppearanceSettings = (): JSX.Element => {
 		hideSelfView,
 		controlButtonsBar
 	} = useAppSelector((state) => state.settings);
+	const browser = useAppSelector((state) => state.me.browser);
 
 	const handleChange = (
 		event: React.ChangeEvent<HTMLInputElement>,
@@ -55,17 +56,19 @@ const AppearanceSettings = (): JSX.Element => {
 					}
 					label={hideSelfViewLabel()}
 				/>
-				<FormControlLabel
-					control={
-						<Switch
-							disabled={hideSelfView}
-							checked={controlButtonsBar}
-							onChange={(event) => handleChange(event, 'controlButtonsBar')}
-							inputProps={{ 'aria-label': 'controlled' }}
-						/>
-					}
-					label={controlButtonsBarLabel()}
-				/>
+				{ browser.platform !== 'mobile' && (
+					<FormControlLabel
+						control={
+							<Switch
+								disabled={hideSelfView}
+								checked={controlButtonsBar}
+								onChange={(event) => handleChange(event, 'controlButtonsBar')}
+								inputProps={{ 'aria-label': 'controlled' }}
+							/>
+						}
+						label={controlButtonsBarLabel()}
+					/>
+				) }
 				<FormControlLabel
 					control={
 						<Switch


### PR DESCRIPTION
This PR solves partially the problem in #85. The media controls are moved on the bottom of the interface, and the settings that can be used to separate them for personal videobox are hidden. This happens only on mobile. You can see the changes in the following screenshots:

![image](https://user-images.githubusercontent.com/35871747/236264842-e229dd31-4327-4b4e-a560-270ba3190db0.png)

![image](https://user-images.githubusercontent.com/35871747/236265625-18ed90dc-b5f6-48d2-b391-acb9c9f6ce7a.png)