### PR TITLE
Build/eol node 16

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Please fill in the appropriate fields to help us solve your issue
 title: "[BUG]"
 labels: bug
-assignees: havfo
+assignees: havfo, pnts-se
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[FEATURE REQUEST]"
 labels: enhancement
-assignees: havfo
+assignees: havfo, pnts-se
 
 ---
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
closes #105 

This PR will 

1. Remove support for node 16 in github workflows
2. Add pnts-se as default assignee for issues