### PR TITLE
fix: redirect to landing page when leaving room

### DIFF
--- a/src/components/textbuttons/LeaveButton.tsx
+++ b/src/components/textbuttons/LeaveButton.tsx
@@ -1,16 +1,14 @@
 import { Button } from '@mui/material';
-import { useNavigate } from 'react-router-dom';
 import { leaveLabel } from '../translated/translatedComponents';
 
 const LeaveButton = (): JSX.Element => {
-	const navigate = useNavigate();
 
 	return (
 		<Button
 			aria-label={leaveLabel()}
 			color='error'
 			variant='contained'
-			onClick={() => navigate('/')}
+			onClick={() => location.replace(window.location.href.split('?')[0])}
 			size='small'
 		>
 			{ leaveLabel() }


### PR DESCRIPTION
closes #108 

This PR will redirect user to landing page when leaving the meeting, so the user doesn't have to manually refresh the page.