### PR TITLE
add audioinput volume indicator in preview

### DIFF
--- a/src/components/mediapreview/MediaPreview.tsx
+++ b/src/components/mediapreview/MediaPreview.tsx
@@ -5,6 +5,9 @@ import WebcamPreviewButton from '../controlbuttons/WebcamPreviewButton';
 import MediaControls from '../mediacontrols/MediaControls';
 import VideoBox from '../videobox/VideoBox';
 import VideoView from '../videoview/VideoView';
+import { useContext } from 'react';
+import { ServiceContext } from '../../store/store';
+import Volume from '../volume/Volume';
 
 interface MediaPreviewProps {
 	withControls?: boolean;
@@ -14,8 +17,10 @@ const MediaPreview = ({
 	withControls = true,
 }: MediaPreviewProps): JSX.Element => {
 	const theme = useTheme();
+	const { mediaService } = useContext(ServiceContext);
 	const { previewWebcamTrackId } = useAppSelector((state) => state.media);
 	const aspectRatio = useAppSelector((state) => state.settings.aspectRatio);
+	const previewVolumeWatcher = mediaService.previewVolumeWatcher;
 
 	return (
 		<>
@@ -48,6 +53,7 @@ const MediaPreview = ({
 					mirrored
 					trackId={previewWebcamTrackId}
 				/> }
+				{previewVolumeWatcher && <Volume previewVolumeWatcher={previewVolumeWatcher} />}
 			</VideoBox>
 		</>
 	);

--- a/src/components/volume/Volume.tsx
+++ b/src/components/volume/Volume.tsx
@@ -41,12 +41,14 @@ interface VolumeProps {
 	small?: boolean;
 	consumer?: StateConsumer;
 	producer?: StateProducer;
+	previewVolumeWatcher?: VolumeWatcher;
 }
 
 const Volume = ({
 	small = false,
 	consumer,
-	producer
+	producer,
+	previewVolumeWatcher
 }: VolumeProps): JSX.Element => {
 	const { mediaService } = useContext(ServiceContext);
 	const [ volume, setVolume ] = useState<number>(0);
@@ -65,6 +67,9 @@ const Volume = ({
 
 		if (media)
 			volumeWatcher = media.appData.volumeWatcher as VolumeWatcher;
+		
+		if (previewVolumeWatcher)
+			volumeWatcher = previewVolumeWatcher;
 
 		const onVolumeChange = ({ scaledVolume }: { scaledVolume: number }): void => {
 			setVolume(scaledVolume);
@@ -75,7 +80,7 @@ const Volume = ({
 		return () => {
 			volumeWatcher?.off('volumeChange', onVolumeChange);
 		};
-	}, [ consumer, producer ]);
+	}, [ consumer, producer, previewVolumeWatcher ]);
 
 	// Props workaround for: https://github.com/mui/material-ui/issues/25925
 	return (

--- a/src/services/mediaService.tsx
+++ b/src/services/mediaService.tsx
@@ -114,6 +114,8 @@ export class MediaService extends EventEmitter {
 	private speechRecognition?: any;
 	private speechRecognitionRunning = false;
 
+	public previewVolumeWatcher?: VolumeWatcher;
+
 	constructor({ signalingService }: { signalingService: SignalingService }) {
 		super();
 
@@ -357,7 +359,6 @@ export class MediaService extends EventEmitter {
 							id,
 							kind,
 							rtpParameters,
-							// type,
 							appData,
 							producerPaused,
 						} = notification.data;
@@ -790,7 +791,7 @@ export class MediaService extends EventEmitter {
 			const producerHark = hark(harkStream, {
 				play: false,
 				interval: 100,
-				threshold: -60, // TODO: get from state
+				threshold: -60,
 				history: 100
 			});
 


### PR DESCRIPTION
closes #113 

This PR adds volume indicator when selecting audioinput device in preview (join view, lobby view and mediasettings component).

![audio-volume-preview](https://github.com/edumeet/edumeet-client/assets/66301426/d59c2e52-9687-48fd-8f14-e898816da7c7)
