### PR TITLE
fix: use live device in preview

### DIFF
--- a/src/components/controlbuttons/SettingsButton.tsx
+++ b/src/components/controlbuttons/SettingsButton.tsx
@@ -15,13 +15,14 @@ const SettingsButton = ({
 }: ControlButtonProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 	const settingsOpen = useAppSelector((state) => state.ui.settingsOpen);
+	const { liveAudioInputDeviceId, liveVideoDeviceId } = useAppSelector((state) => state.media);
 
 	return (
 		<ControlButton
 			toolTip={showSettingsLabel()}
 			onClick={() => {
-				dispatch(updatePreviewMic());
-				dispatch(updatePreviewWebcam());
+				dispatch(updatePreviewMic(liveAudioInputDeviceId));
+				dispatch(updatePreviewWebcam(liveVideoDeviceId));
 				dispatch(uiActions.setUi({ settingsOpen: !settingsOpen }));
 			}}
 			{ ...props }


### PR DESCRIPTION
This PR will change the behavior of in-meeting MediaSettings dialog.
It will now use live deviceId for audio and video, if they exists.
If you have video and/or audio active, those deviceIds will be loaded in preview.