### PR TITLE
fix/persist preview audio and video devices

### DIFF
--- a/src/components/controlbuttons/MicPreviewButton.tsx
+++ b/src/components/controlbuttons/MicPreviewButton.tsx
@@ -8,13 +8,14 @@ import MicIcon from '@mui/icons-material/Mic';
 import MicOffIcon from '@mui/icons-material/MicOff';
 import ControlButton, { ControlButtonProps } from './ControlButton';
 import { updatePreviewMic, stopPreviewMic } from '../../store/actions/mediaActions';
+import { mediaActions } from '../../store/slices/mediaSlice';
 
 const MicPreviewButton = (props: ControlButtonProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 
 	const {
 		previewMicTrackId,
-		audioInProgress,
+		audioInProgress, previewAudioInputDeviceId
 	} = useAppSelector((state) => state.media);
 
 	let micState: MediaState, micTip;
@@ -32,8 +33,9 @@ const MicPreviewButton = (props: ControlButtonProps): JSX.Element => {
 			toolTip={micTip}
 			onClick={() => {
 				if (micState === 'off') {
-					dispatch(updatePreviewMic());
+					dispatch(updatePreviewMic(previewAudioInputDeviceId));
 				} else if (previewMicTrackId) {
+					dispatch(mediaActions.setAudioMuted(true));
 					dispatch(stopPreviewMic());
 				} else {
 					// Shouldn't happen

--- a/src/components/controlbuttons/WebcamPreviewButton.tsx
+++ b/src/components/controlbuttons/WebcamPreviewButton.tsx
@@ -11,11 +11,12 @@ import {
 	updatePreviewWebcam,
 	stopPreviewWebcam
 } from '../../store/actions/mediaActions';
+import { mediaActions } from '../../store/slices/mediaSlice';
 
 const WebcamPreviewButton = (props: ControlButtonProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 
-	const { previewAudioInputDeviceId,
+	const { previewVideoDeviceId,
 		previewWebcamTrackId,
 		videoInProgress	} = useAppSelector((state) => state.media);
 
@@ -36,8 +37,9 @@ const WebcamPreviewButton = (props: ControlButtonProps): JSX.Element => {
 				if (webcamState === 'unsupported') return;
 
 				if (webcamState === 'off') {
-					dispatch(updatePreviewWebcam(previewAudioInputDeviceId));
+					dispatch(updatePreviewWebcam(previewVideoDeviceId));
 				} else if (previewWebcamTrackId) {
+					dispatch(mediaActions.setVideoMuted(true));
 					dispatch(stopPreviewWebcam());
 				} else {
 					// Shouldn't happen

--- a/src/store/actions/mediaActions.tsx
+++ b/src/store/actions/mediaActions.tsx
@@ -190,7 +190,6 @@ export const stopPreviewMic = (): AppThunk<Promise<void>> => async (
 		const track = mediaService.getTrack(previewMicTrackId, 'previewTracks');
 
 		dispatch(mediaActions.setPreviewMicTrackId());
-		dispatch(mediaActions.setPreviewAudioInputDeviceId());
 
 		mediaService.removePreviewTrack(track?.id);
 		track?.stop();
@@ -198,7 +197,6 @@ export const stopPreviewMic = (): AppThunk<Promise<void>> => async (
 
 	delete mediaService.previewVolumeWatcher;
 
-	dispatch(mediaActions.setPreviewAudioInputDeviceId());
 	dispatch(mediaActions.setAudioInProgress(false));
 };
 
@@ -326,7 +324,6 @@ export const stopPreviewWebcam = (): AppThunk<Promise<void>> => async (
 	}
 
 	previewBlurBackground && effectService.stopBlurEffect('preview');
-	dispatch(mediaActions.setPreviewVideoDeviceId());
 	dispatch(mediaActions.setVideoInProgress(false));
 };
 

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -64,10 +64,16 @@ export interface MiddlewareOptions {
 }
 
 const persistConfig = {
-	key: 'root',
+	key: 'edumeetRoot',
 	storage,
 	stateReconciler: autoMergeLevel2,
 	whitelist: [ 'settings' ]
+};
+
+const mediaPersistConfig = {
+	key: 'edumeetMedia',
+	storage,
+	whitelist: [ 'previewVideoDeviceId', 'previewAudioInputDeviceId' ]
 };
 
 const signalingService = new SignalingService();
@@ -116,7 +122,7 @@ const reducer = combineReducers({
 	ui: uiSlice.reducer,
 	webrtc: webrtcSlice.reducer,
 	recording: recordingSlice.reducer,
-	media: mediaSlice.reducer
+	media: persistReducer(mediaPersistConfig, mediaSlice.reducer)
 });
 
 const pReducer = persistReducer<RootState>(persistConfig, reducer);


### PR DESCRIPTION
This PR will:
* persist state deviceId of previewAudioInput and previewVideo.
* use them as default when joining a new meeting.
* rename local storage keys for redux-persist

We only persist those two variables of the media slice, nothing else.