### PR TITLE
Fix/media buttons mediasettings

### DIFF
--- a/src/components/controlbuttons/MicButton.tsx
+++ b/src/components/controlbuttons/MicButton.tsx
@@ -16,20 +16,17 @@ import {
 import MicIcon from '@mui/icons-material/Mic';
 import MicOffIcon from '@mui/icons-material/MicOff';
 import ControlButton, { ControlButtonProps } from './ControlButton';
-import { updateLiveMic, updatePreviewMic, updatePreviewWebcam } from '../../store/actions/mediaActions';
-import { uiActions } from '../../store/slices/uiSlice';
+import { updateLiveMic } from '../../store/actions/mediaActions';
 
 const MicButton = (props: ControlButtonProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 	const hasAudioPermission = usePermissionSelector(permissions.SHARE_AUDIO);
 	const micProducer = useAppSelector(micProducerSelector);
+	const {	audioInProgress } = useAppSelector((state) => state.media);
 
 	const {
 		canSendMic,
 	} = useAppSelector((state) => state.me);
-
-	const {	audioInProgress, liveAudioInputDeviceId } = useAppSelector((state) => state.media);
-	const { settingsOpen } = useAppSelector((state) => state.ui);
 
 	let micState: MediaState, micTip;
 

--- a/src/components/controlbuttons/MicButton.tsx
+++ b/src/components/controlbuttons/MicButton.tsx
@@ -54,13 +54,7 @@ const MicButton = (props: ControlButtonProps): JSX.Element => {
 				if (micState === 'unsupported') return;
 
 				if (micState === 'off') {
-					if (liveAudioInputDeviceId) {
-						dispatch(updateLiveMic());
-					} else {
-						dispatch(updatePreviewMic());
-						dispatch(updatePreviewWebcam());
-						dispatch(uiActions.setUi({ settingsOpen: !settingsOpen })); 
-					}
+					dispatch(updateLiveMic());
 				} else if (micProducer) {
 					if (micState === 'on') {
 						dispatch(

--- a/src/components/controlbuttons/MicPreviewButton.tsx
+++ b/src/components/controlbuttons/MicPreviewButton.tsx
@@ -15,7 +15,7 @@ const MicPreviewButton = (props: ControlButtonProps): JSX.Element => {
 
 	const {
 		previewMicTrackId,
-		audioInProgress, previewAudioInputDeviceId
+		audioInProgress, liveAudioInputDeviceId
 	} = useAppSelector((state) => state.media);
 
 	let micState: MediaState, micTip;
@@ -33,7 +33,7 @@ const MicPreviewButton = (props: ControlButtonProps): JSX.Element => {
 			toolTip={micTip}
 			onClick={() => {
 				if (micState === 'off') {
-					dispatch(updatePreviewMic(previewAudioInputDeviceId));
+					dispatch(updatePreviewMic(liveAudioInputDeviceId));
 				} else if (previewMicTrackId) {
 					dispatch(mediaActions.setAudioMuted(true));
 					dispatch(stopPreviewMic());

--- a/src/components/controlbuttons/WebcamButton.tsx
+++ b/src/components/controlbuttons/WebcamButton.tsx
@@ -15,16 +15,14 @@ import {
 import VideoIcon from '@mui/icons-material/Videocam';
 import VideoOffIcon from '@mui/icons-material/VideocamOff';
 import ControlButton, { ControlButtonProps } from './ControlButton';
-import { stopLiveWebcam, updateLiveWebcam, updatePreviewMic, updatePreviewWebcam } from '../../store/actions/mediaActions';
-import { uiActions } from '../../store/slices/uiSlice';
+import { stopLiveWebcam, updateLiveWebcam } from '../../store/actions/mediaActions';
 
 const WebcamButton = (props: ControlButtonProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 	const hasVideoPermission = usePermissionSelector(permissions.SHARE_VIDEO);
 	const webcamProducer = useAppSelector(webcamProducerSelector);
-	const { liveVideoDeviceId, videoInProgress } = useAppSelector((state) => state.media);
+	const { videoInProgress } = useAppSelector((state) => state.media);
 	const {	canSendWebcam } = useAppSelector((state) => state.me);
-	const { settingsOpen } = useAppSelector((state) => state.ui);
 
 	let webcamState!: MediaState, webcamTip;
 
@@ -46,13 +44,7 @@ const WebcamButton = (props: ControlButtonProps): JSX.Element => {
 				if (webcamState === 'unsupported') return;
 
 				if (webcamState === 'off') {
-					if (liveVideoDeviceId) {
-						dispatch(updateLiveWebcam());
-					} else {
-						dispatch(updatePreviewMic());
-						dispatch(updatePreviewWebcam());
-						dispatch(uiActions.setUi({ settingsOpen: !settingsOpen })); 
-					}
+					dispatch(updateLiveWebcam());
 				}
 
 				if (webcamProducer) {

--- a/src/components/controlbuttons/WebcamPreviewButton.tsx
+++ b/src/components/controlbuttons/WebcamPreviewButton.tsx
@@ -16,7 +16,7 @@ import { mediaActions } from '../../store/slices/mediaSlice';
 const WebcamPreviewButton = (props: ControlButtonProps): React.JSX.Element => {
 	const dispatch = useAppDispatch();
 
-	const { previewVideoDeviceId,
+	const { liveVideoDeviceId,
 		previewWebcamTrackId,
 		videoInProgress	} = useAppSelector((state) => state.media);
 
@@ -35,7 +35,7 @@ const WebcamPreviewButton = (props: ControlButtonProps): React.JSX.Element => {
 			toolTip={webcamTip}
 			onClick={() => {
 				if (webcamState === 'off') {
-					dispatch(updatePreviewWebcam(previewVideoDeviceId));
+					dispatch(updatePreviewWebcam(liveVideoDeviceId));
 				} else {
 					dispatch(mediaActions.setVideoMuted(true));
 					dispatch(stopPreviewWebcam());

--- a/src/components/devicechooser/AudioInputChooser.tsx
+++ b/src/components/devicechooser/AudioInputChooser.tsx
@@ -22,7 +22,7 @@ const AudioInputChooser = ({
 }: AudioInputChooserProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 	const audioDevices = useDeviceSelector('audioinput');
-	const { audioInProgress, previewAudioInputDeviceId } = useAppSelector((state) => state.media);
+	const { audioInProgress, previewAudioInputDeviceId, liveAudioInputDeviceId } = useAppSelector((state) => state.media);
 
 	const handleDeviceChange = (deviceId: string): void => {
 		if (deviceId) {
@@ -39,7 +39,7 @@ const AudioInputChooser = ({
 	return (
 		<ChooserDiv>
 			<DeviceChooser
-				value={previewAudioInputDeviceId ?? ''}
+				value={liveAudioInputDeviceId ?? previewAudioInputDeviceId ?? ''}
 				setValue={handleDeviceChange}
 				devicesLabel={selectAudioInputDeviceLabel()}
 				noDevicesLabel={noAudioInputDevicesLabel()}

--- a/src/components/devicechooser/VideoInputChooser.tsx
+++ b/src/components/devicechooser/VideoInputChooser.tsx
@@ -22,7 +22,7 @@ const VideoInputChooser = ({
 }: VideoInputChooserProps): JSX.Element => {
 	const dispatch = useAppDispatch();
 	const videoDevices = useDeviceSelector('videoinput');
-	const { videoInProgress, previewVideoDeviceId, previewBlurBackground } = useAppSelector((state) => state.media);
+	const { videoInProgress, liveVideoDeviceId, previewVideoDeviceId, previewBlurBackground } = useAppSelector((state) => state.media);
 
 	const handleDeviceChange = (deviceId: string): void => {
 		if (deviceId) {
@@ -42,7 +42,7 @@ const VideoInputChooser = ({
 	return (
 		<ChooserDiv>
 			<DeviceChooser
-				value={previewVideoDeviceId ?? ''}
+				value={liveVideoDeviceId ?? previewVideoDeviceId ?? ''}
 				setValue={handleDeviceChange}
 				devicesLabel={selectVideoDeviceLabel()}
 				noDevicesLabel={noVideoDevicesLabel()}

--- a/src/store/actions/mediaActions.tsx
+++ b/src/store/actions/mediaActions.tsx
@@ -432,7 +432,7 @@ export const updateAudioSettings = (
  * @param options - Options.
  * @returns {Promise<void>} Promise.
  */
-export const updateLiveMic = (): AppThunk<Promise<void>> => async (
+export const updateLiveMic = (newDeviceId?: string): AppThunk<Promise<void>> => async (
 	dispatch,
 	getState,
 	{ mediaService, deviceService }
@@ -480,9 +480,6 @@ export const updateLiveMic = (): AppThunk<Promise<void>> => async (
 			opusMaxPlaybackRate,
 		} = getState().settings;
 
-		if (!liveAudioInputDeviceId)
-			throw new Error('Selected live audio device not found');
-
 		micProducer =
 			mediaService.getProducers()
 				.find((producer) => producer.appData.source === 'mic');
@@ -496,11 +493,12 @@ export const updateLiveMic = (): AppThunk<Promise<void>> => async (
 				local: true
 			}));
 		}
+
+		const deviceId = newDeviceId ?? liveAudioInputDeviceId;
 			
-		// At this point we want the exact device, or none at all.
 		const stream = await navigator.mediaDevices.getUserMedia({
 			audio: {
-				deviceId: { exact: liveAudioInputDeviceId },
+				deviceId: { ideal: deviceId },
 				sampleRate,
 				channelCount,
 				autoGainControl,

--- a/src/store/actions/mediaActions.tsx
+++ b/src/store/actions/mediaActions.tsx
@@ -494,7 +494,7 @@ export const updateLiveMic = (newDeviceId?: string): AppThunk<Promise<void>> => 
 			}));
 		}
 
-		const deviceId = newDeviceId ?? liveAudioInputDeviceId;
+		let deviceId = newDeviceId ?? liveAudioInputDeviceId;
 			
 		const stream = await navigator.mediaDevices.getUserMedia({
 			audio: {
@@ -509,11 +509,11 @@ export const updateLiveMic = (newDeviceId?: string): AppThunk<Promise<void>> => 
 		});
 
 		track = stream.getAudioTracks()[0];
+		if (!track) throw new Error('no live mic track');
+		deviceId = track.getSettings().deviceId;
+		if (!deviceId) throw new Error('No deviceId');
 
-		if (!track)
-			throw new Error('no live mic track');
-
-		mediaService.addTrack(track, liveAudioInputDeviceId, 'liveTracks');
+		mediaService.addTrack(track, deviceId, 'liveTracks');
 		dispatch(mediaActions.setLiveMicTrackId(track.id));
 
 		micProducer = await mediaService.produce({
@@ -689,11 +689,9 @@ export const updateLiveWebcam = (newVideoDeviceId?: string): AppThunk<Promise<vo
 		});
 
 		track = stream.getVideoTracks()[0];
+		if (!track) throw new Error('no live webcam track');
 		deviceId = track.getSettings().deviceId;
 		if (!deviceId) throw new Error('No deviceId');
-
-		if (!track)
-			throw new Error('no live webcam track');
 
 		let blurTrack: MediaStreamTrack | undefined;
 		let width: number | undefined, height: number | undefined;

--- a/src/store/actions/roomActions.tsx
+++ b/src/store/actions/roomActions.tsx
@@ -87,7 +87,7 @@ export const joinRoom = (): AppThunk<Promise<void>> => async (
 		dispatch(webrtcActions.setTracker(tracker));
 
 		const { canBlurBackground, canSelectAudioOutput } = getState().me;
-		const { videoMuted, audioMuted, previewVideoDeviceId, previewAudioInputDeviceId, previewBlurBackground, previewAudioOutputDeviceId } = getState().media;
+		const { videoMuted, audioMuted, previewVideoDeviceId, liveVideoDeviceId, previewAudioInputDeviceId, liveAudioInputDeviceId, previewBlurBackground, previewAudioOutputDeviceId } = getState().media;
 
 		if (canBlurBackground)
 			dispatch(mediaActions.setLiveBlurBackground(previewBlurBackground));
@@ -95,11 +95,11 @@ export const joinRoom = (): AppThunk<Promise<void>> => async (
 			dispatch(mediaActions.setLiveAudioOutputDeviceId(previewAudioOutputDeviceId));
 		}
 		
-		if (!audioMuted && previewAudioInputDeviceId) {
-			dispatch(mediaActions.setLiveAudioInputDeviceId(previewAudioInputDeviceId));
+		if (!audioMuted) {
+			dispatch(mediaActions.setLiveAudioInputDeviceId(previewAudioInputDeviceId ?? liveAudioInputDeviceId ?? undefined));
 		}
-		if (!videoMuted && previewVideoDeviceId) {
-			dispatch(mediaActions.setLiveVideoDeviceId(previewVideoDeviceId));
+		if (!videoMuted) {
+			dispatch(mediaActions.setLiveVideoDeviceId(previewVideoDeviceId ?? liveVideoDeviceId ?? undefined));
 		}
 
 		dispatch(stopPreviewMic());

--- a/src/store/middlewares/signalingMiddleware.tsx
+++ b/src/store/middlewares/signalingMiddleware.tsx
@@ -44,7 +44,6 @@ const createSignalingMiddleware = ({
 							message: roomServerConnectionSuccess(),
 							options: { variant: 'success' }
 						}));
-						dispatch(signalingActions.setReconnectAttempts(0));
 					}
 
 					dispatch(signalingActions.connected());

--- a/src/store/slices/mediaSlice.tsx
+++ b/src/store/slices/mediaSlice.tsx
@@ -85,14 +85,13 @@ const mediaSlice = createSlice({
 			state.videoInProgress = action.payload;
 		}),
 		testAudioOutput: () => {
-			// handle in middleWare
+			// handled in notificationMiddleWare.
 		},
 		resetLiveWebcam: ((state) => {
 			state.liveWebcamTrackId = undefined;
 			state.videoMuted = true;
 		}),
 		resetLiveMic: ((state) => {
-			state.liveAudioInputDeviceId = undefined;
 			state.liveMicTrackId = undefined;
 			state.audioMuted = true;
 		})

--- a/src/store/slices/mediaSlice.tsx
+++ b/src/store/slices/mediaSlice.tsx
@@ -88,7 +88,6 @@ const mediaSlice = createSlice({
 			// handle in middleWare
 		},
 		resetLiveWebcam: ((state) => {
-			state.liveVideoDeviceId = undefined;
 			state.liveWebcamTrackId = undefined;
 			state.videoMuted = true;
 		}),

--- a/src/store/slices/signalingSlice.tsx
+++ b/src/store/slices/signalingSlice.tsx
@@ -23,6 +23,7 @@ const signalingSlice = createSlice({
 		}),
 		connected: ((state) => {
 			state.state = 'connected';
+			state.reconnectAttempts = 0;
 		}),
 		disconnect: ((state) => {
 			state.state = 'disconnected';

--- a/src/store/store.tsx
+++ b/src/store/store.tsx
@@ -73,7 +73,7 @@ const persistConfig = {
 const mediaPersistConfig = {
 	key: 'edumeetMedia',
 	storage,
-	whitelist: [ 'previewVideoDeviceId', 'previewAudioInputDeviceId', 'previewAudioOutputDeviceId' ]
+	whitelist: [ 'liveVideoDeviceId', 'liveAudioInputDeviceId', 'liveAudioOutputDeviceId' ]
 };
 
 const signalingService = new SignalingService();


### PR DESCRIPTION
closes #147 

This PR will revert behavior of clicking webcam- and micbutton in-meeting.
We remove behavior to open mediasetting to let user choose devices.
Instead we call `updateLiveMic()` and `updateLiveWebcam()`, potentially calling `mediaDevices.getUserMedia()`