### PR TITLE
Feat/handle websocket disconnection

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { startListeners, stopListeners } from './store/actions/startActions';
 import {
 	useAppDispatch,
@@ -44,6 +44,7 @@ const App = (): JSX.Element => {
 	const roomState = useAppSelector((state) => state.room.state) as RoomConnectionState;
 	const id = (useParams<AppParams>() as AppParams).id.toLowerCase();
 	const hasFilesharingPermission = usePermissionSelector(permissions.SHARE_FILE);
+	const navigate = useNavigate();
 
 	useEffect(() => {
 		dispatch(startListeners());
@@ -66,6 +67,13 @@ const App = (): JSX.Element => {
 			dispatch(sendFiles(droppedFiles));
 		}
 	};
+
+	useEffect(() => {
+		if (roomState ==='left') {
+			dispatch(roomActions.setState('new'));
+			navigate('/');
+		}
+	}, [ roomState ]);
 
 	return (
 		<SnackbarProvider action={

--- a/src/components/textbuttons/LeaveButton.tsx
+++ b/src/components/textbuttons/LeaveButton.tsx
@@ -1,16 +1,13 @@
 import { Button } from '@mui/material';
 import { leaveLabel } from '../translated/translatedComponents';
-import { useNavigate } from 'react-router-dom';
 import { useAppDispatch } from '../../store/hooks';
 import { leaveRoom } from '../../store/actions/roomActions';
 
 const LeaveButton = (): React.JSX.Element => {
-	const navigate = useNavigate();
 	const dispatch = useAppDispatch();
 
 	const handleLeave = () => {
 		dispatch(leaveRoom());
-		navigate('/');
 	};
 
 	return (

--- a/src/components/translated/translatedComponents.tsx
+++ b/src/components/translated/translatedComponents.tsx
@@ -748,22 +748,7 @@ export const mediaNodeConnectionSuccess = (): string => intl.formatMessage({
 	defaultMessage: 'Media-Node service: Got connection'
 });
 
-export const roomServerLostConnection = (): string => intl.formatMessage({
-	id: 'svc.roomServerLostConnection',
-	defaultMessage: 'Room-server: Lost connection'
-});
-
-export const roomServerRetryingConection = (attempt: number): string => intl.formatMessage({
-	id: 'svc.roomServerRetryingConnection',
-	defaultMessage: `Room-server: Retrying connection. Attempt: ${attempt}`
-});
-
 export const roomServerConnectionError = (message: string): string => intl.formatMessage({
 	id: 'svc.roomServerConnectionError',
 	defaultMessage: `Room-server: ${message}`
-});
-
-export const roomServerConnectionSuccess = (): string => intl.formatMessage({
-	id: 'svc.roomServerConnectionSuccess',
-	defaultMessage: 'Room-server: Got connection'
 });

--- a/src/store/actions/roomActions.tsx
+++ b/src/store/actions/roomActions.tsx
@@ -108,12 +108,11 @@ export const joinRoom = (): AppThunk<Promise<void>> => async (
 };
 
 export const leaveRoom = (): AppThunk<Promise<void>> => async (
-	dispatch, getState, { mediaService }
+	dispatch 
 ): Promise<void> => {
 	logger.debug('leaveRoom()');
 
-	mediaService.removeAllListeners();
-	mediaService.close();
+	dispatch(roomActions.setState('left'));
 	dispatch(signalingActions.disconnect());
 	dispatch(meActions.resetMe());
 };

--- a/src/store/middlewares/mediaMiddleware.tsx
+++ b/src/store/middlewares/mediaMiddleware.tsx
@@ -12,7 +12,6 @@ import { mediaActions } from '../slices/mediaSlice';
 import { mediaNodeConnectionError, mediaNodeConnectionSuccess, mediaNodeSvcUnavailable } from '../../components/translated/translatedComponents';
 import { meActions } from '../slices/meSlice';
 import { startMedia } from '../actions/mediaActions';
-import { signalingActions } from '../slices/signalingSlice';
 
 const logger = new Logger('MediaMiddleware');
 
@@ -46,10 +45,6 @@ const createMediaMiddleware = ({
 		getState: () => RootState
 	}) =>
 		(next) => async (action) => {
-			if (signalingActions.setReconnectAttempts.match(action)) {
-				// TODO: How do we handle reconnect?
-			}
-			
 			if (roomActions.setState.match(action) && action.payload === 'left') {
 				mediaService.close();
 				mediaService.removeAllListeners();

--- a/src/store/middlewares/roomMiddleware.tsx
+++ b/src/store/middlewares/roomMiddleware.tsx
@@ -27,10 +27,6 @@ const createRoomMiddleware = ({
 		getState: () => RootState
 	}) =>
 		(next) => (action) => {
-			if (signalingActions.disconnect.match(action)) {
-				dispatch(roomActions.setState('left'));
-			}
-
 			if (signalingActions.connect.match(action)) {
 				signalingService.on('notification', (notification) => {
 					try {

--- a/src/store/slices/signalingSlice.tsx
+++ b/src/store/slices/signalingSlice.tsx
@@ -1,17 +1,15 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
-export type SignalingConnectionState = 'new' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
+export type SignalingConnectionState = 'new' | 'connecting' | 'connected' | 'disconnected';
 
 export interface SignalingState {
 	state: SignalingConnectionState;
 	url: string;
-	reconnectAttempts: number
 }
 
 const initialState: SignalingState = {
 	state: 'new',
 	url: 'wss://localhost',
-	reconnectAttempts: 0
 };
 
 const signalingSlice = createSlice({
@@ -23,21 +21,13 @@ const signalingSlice = createSlice({
 		}),
 		connected: ((state) => {
 			state.state = 'connected';
-			state.reconnectAttempts = 0;
 		}),
 		disconnect: ((state) => {
 			state.state = 'disconnected';
 		}),
-		reconnecting: ((state) => {
-			state.state = 'reconnecting';
-		}),
 		setUrl: ((state, action: PayloadAction<string>) => {
 			state.url = action.payload;
 		}),
-		setReconnectAttempts: ((state, action: PayloadAction<number>) => {
-			state.reconnectAttempts = action.payload;
-		}),
-
 	},
 });
 

--- a/src/utils/RoomServerConnection.tsx
+++ b/src/utils/RoomServerConnection.tsx
@@ -101,7 +101,7 @@ export class RoomServerConnection extends EventEmitter {
 			} catch (error) {
 				if (error instanceof SocketTimeoutError) {
 					logger.warn('sendRequest() timeout, retrying [attempt: %s]', tries + 1);
-					this.emit('error', new Error(`socket timeout attempt: ${tries + 1}`));
+					this.emit('error', new Error('Socket timeout'));
 				} else
 					throw error;
 			}

--- a/src/utils/RoomServerConnection.tsx
+++ b/src/utils/RoomServerConnection.tsx
@@ -26,6 +26,8 @@ interface ServerClientEvents {
 const logger = new Logger('RoomServerConnection');
 
 export class RoomServerConnection extends EventEmitter {
+	public id: string;
+
 	public static create({ url }: { url: string}): RoomServerConnection {
 		logger.debug('create() [url:%s]', url);
 	
@@ -33,6 +35,7 @@ export class RoomServerConnection extends EventEmitter {
 			transports: [ 'websocket', 'polling' ],
 			rejectUnauthorized: false,
 			closeOnBeforeunload: false,
+			reconnection: false
 		});
 	
 		return new RoomServerConnection(socket);
@@ -47,6 +50,7 @@ export class RoomServerConnection extends EventEmitter {
 		logger.debug('constructor()');
 
 		this.socket = socket;
+		this.id = socket.id;
 		this.handleSocket();
 	}
 
@@ -58,14 +62,11 @@ export class RoomServerConnection extends EventEmitter {
 
 		if (this.socket.connected)
 			this.socket.disconnect();
+		this.socket.io.off();
 
 		this.socket.removeAllListeners();
 
 		this.emit('close');
-	}
-
-	public get id(): string {
-		return this.socket.id;
 	}
 
 	@skipIfClosed
@@ -81,7 +82,7 @@ export class RoomServerConnection extends EventEmitter {
 			if (!this.socket) {
 				reject('No socket connection');
 			} else {
-				this.socket.timeout(3000).emit('request', socketMessage, (timeout, serverError, response) => {
+				this.socket.timeout(1500).emit('request', socketMessage, (timeout, serverError, response) => {
 					if (timeout) reject(new SocketTimeoutError('Request timed out'));
 					else if (serverError) reject(serverError);
 					else resolve(response);
@@ -98,9 +99,10 @@ export class RoomServerConnection extends EventEmitter {
 			try {
 				return await this.sendRequestOnWire(request);
 			} catch (error) {
-				if (error instanceof SocketTimeoutError)
-					logger.warn('sendRequest() timeout, retrying [attempt: %s]', tries);
-				else
+				if (error instanceof SocketTimeoutError) {
+					logger.warn('sendRequest() timeout, retrying [attempt: %s]', tries + 1);
+					this.emit('error', new Error(`socket timeout attempt: ${tries + 1}`));
+				} else
 					throw error;
 			}
 		}
@@ -115,13 +117,9 @@ export class RoomServerConnection extends EventEmitter {
 			this.emit('connect');
 		});
 
-		this.socket.once('disconnect', (reason) => {
+		this.socket.once('disconnect', () => {
 			logger.debug('socket disconnected');
-
-			if (reason === 'io server disconnect')
-				this.close();
-			else
-				this.emit('reconnect');
+			this.close();
 		});
 
 		this.socket.on('notification', (notification) => {
@@ -141,6 +139,11 @@ export class RoomServerConnection extends EventEmitter {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				(error: any) => result(error, null)
 			);
+		});
+
+		// Listen and re-transmit events from manager.
+		this.socket.io.on('error', (error: Error) => {
+			this.emit('error', (error));
 		});
 	}
 }


### PR DESCRIPTION
This PR will mimic Room server behavior and do a full closure when websocket disconnects.
We remove listeners on mediaService and signalingService and leave the room.
We reset me.id so we will be treated like a new peer on rejoin.
This also mean we remove a lot of notifications and events related to websocket reconnection logic.