### PR TITLE
Add support for audio output selection

### DIFF
--- a/src/components/audiooutputtest/AudioOutputTest.tsx
+++ b/src/components/audiooutputtest/AudioOutputTest.tsx
@@ -1,0 +1,36 @@
+import { Button } from '@mui/material';
+import {
+	useAppDispatch,
+	useAppSelector,
+	useDeviceSelector
+} from '../../store/hooks';
+import { notificationsActions } from '../../store/slices/notificationsSlice';
+import { ChooserDiv } from '../devicechooser/DeviceChooser';
+import { testAudioOutputLabel } from '../translated/translatedComponents';
+
+const TestAudioOutputButton = (): JSX.Element => {
+	const audioDevices = useDeviceSelector('audiooutput');
+	const audioInProgress = useAppSelector((state) => state.me.audioInProgress);
+	const dispatch = useAppDispatch();
+
+	const triggerTestSound = (): void => {
+		dispatch(notificationsActions.playTestSound());
+	};
+
+	return (
+		<>
+			{ audioDevices.length > 1 &&
+			<ChooserDiv>
+				<Button
+					variant='contained'
+					onClick={triggerTestSound}
+					disabled={audioInProgress}
+				>
+					{ testAudioOutputLabel() }
+				</Button></ChooserDiv>
+			}
+		</>
+	);
+};
+
+export default TestAudioOutputButton;

--- a/src/components/audiopeers/AudioPeers.tsx
+++ b/src/components/audiopeers/AudioPeers.tsx
@@ -4,6 +4,7 @@ import AudioView from '../audioview/AudioView';
 
 const AudioPeers = (): JSX.Element => {
 	const micConsumers = useAppSelector(audioConsumerSelector);
+	const deviceId = useAppSelector((state) => state.settings.selectedAudioOutputDevice);
 
 	return (
 		<div>
@@ -11,6 +12,7 @@ const AudioPeers = (): JSX.Element => {
 				!consumer.localPaused && !consumer.remotePaused && <AudioView
 					key={consumer.id}
 					consumer={consumer}
+					deviceId={deviceId}
 				/>
 			)) }
 		</div>

--- a/src/components/audioview/AudioView.tsx
+++ b/src/components/audioview/AudioView.tsx
@@ -1,16 +1,19 @@
 import { useContext, useEffect, useRef } from 'react';
 import { StateConsumer } from '../../store/slices/consumersSlice';
 import { ServiceContext } from '../../store/store';
+import { HTMLMediaElementWithSink } from '../../utils/types';
 
 interface AudioViewProps {
 	consumer: StateConsumer;
+	deviceId?: string;
 }
 
 const AudioView = ({
-	consumer
+	consumer,
+	deviceId
 }: AudioViewProps): JSX.Element => {
 	const { mediaService } = useContext(ServiceContext);
-	const audioElement = useRef<HTMLAudioElement>(null);
+	const audioElement = useRef<HTMLMediaElementWithSink>(null);
 
 	useEffect(() => {
 		const { track } = mediaService.getConsumer(consumer.id) ?? {};
@@ -27,6 +30,10 @@ const AudioView = ({
 		stream.addTrack(track);
 		audioElement.current.srcObject = stream;
 
+		if (deviceId) {
+			audioElement.current.setSinkId(deviceId);
+		}
+
 		return () => {
 			if (audioElement.current) {
 				audioElement.current.srcObject = null;
@@ -34,7 +41,7 @@ const AudioView = ({
 				audioElement.current.onpause = null;
 			}
 		};
-	}, []);
+	}, [ deviceId ]);
 
 	useEffect(() => {
 		const { audioGain } = consumer;

--- a/src/components/devicechooser/AudioInputChooser.tsx
+++ b/src/components/devicechooser/AudioInputChooser.tsx
@@ -9,7 +9,7 @@ import {
 import { meProducersSelector } from '../../store/selectors';
 import {
 	applyLabel,
-	audioDeviceLabel,
+	audioInputDeviceLabel,
 	noAudioInputDevicesLabel,
 	selectAudioInputDeviceLabel
 } from '../translated/translatedComponents';
@@ -54,7 +54,7 @@ const AudioInputChooser = ({
 					<DeviceChooser
 						value={selectedAudioDevice ?? ''}
 						setValue={handleDeviceChange}
-						name={audioDeviceLabel()}
+						name={audioInputDeviceLabel()}
 						devicesLabel={selectAudioInputDeviceLabel()}
 						noDevicesLabel={noAudioInputDevicesLabel()}
 						disabled={audioDevices.length < 2 || audioInProgress}

--- a/src/components/devicechooser/AudioOutputChooser.tsx
+++ b/src/components/devicechooser/AudioOutputChooser.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import {
+	useAppDispatch,
+	useAppSelector,
+	useDeviceSelector,
+} from '../../store/hooks';
+import DeviceChooser, { ChooserDiv } from './DeviceChooser';
+import { settingsActions } from '../../store/slices/settingsSlice';
+import { audioOutputDeviceLabel, noAudioOutputDevicesLabel, selectAudioOutputDeviceLabel } from '../translated/translatedComponents';
+
+const AudioOutputChooser = (): JSX.Element => {
+	const dispatch = useAppDispatch();
+	const audioDevices = useDeviceSelector('audiooutput');
+	const audioInProgress = useAppSelector((state) => state.me.audioInProgress);
+	const audioOutputDevice = useAppSelector(
+		(state) => state.settings.selectedAudioOutputDevice
+	);
+	const [ selectedDevice, setSelectedDevice ] =
+    useState(audioOutputDevice);
+
+	const handleDeviceChange = (deviceId: string): void => {
+		if (deviceId) {
+			setSelectedDevice(deviceId);
+			dispatch(settingsActions.setSelectedAudioOutputDevice(deviceId));
+		}
+	};
+
+	return (
+		<>
+			{audioDevices.length > 1 && (
+				<ChooserDiv>
+					<DeviceChooser
+						value={selectedDevice ?? ''}
+						setValue={handleDeviceChange}
+						name={audioOutputDeviceLabel()}
+						devicesLabel={selectAudioOutputDeviceLabel()}
+						noDevicesLabel={noAudioOutputDevicesLabel()}
+						disabled={audioDevices.length < 2 || audioInProgress}
+						devices={audioDevices}
+					/>
+				</ChooserDiv>
+			)}
+		</>
+	);
+};
+
+export default AudioOutputChooser;

--- a/src/components/settingsdialog/MediaSettings.tsx
+++ b/src/components/settingsdialog/MediaSettings.tsx
@@ -3,17 +3,23 @@ import AudioInputChooser from '../devicechooser/AudioInputChooser';
 import VideoInputChooser from '../devicechooser/VideoInputChooser';
 import MediaPreview from '../mediapreview/MediaPreview';
 import { BlurSwitch } from './SettingsSwitches';
+import { useAppSelector } from '../../store/hooks';
+import { canSelectAudioOutput } from '../../store/selectors';
+import AudioOutputChooser from '../devicechooser/AudioOutputChooser';
 
 const NestedList = styled(List)(({ theme }) => ({
 	padding: theme.spacing(0, 1.5)
 }));
 
 const MediaSettings = (): JSX.Element => {
+	const showAudioOutputChooser = useAppSelector(canSelectAudioOutput);
+
 	return (
 		<List>
 			<MediaPreview withControls={false} />
 			<NestedList>
 				<AudioInputChooser withConfirm />
+				{showAudioOutputChooser && <AudioOutputChooser /> }
 			</NestedList>
 			<NestedList>
 				<VideoInputChooser withConfirm />

--- a/src/components/translated/translatedComponents.tsx
+++ b/src/components/translated/translatedComponents.tsx
@@ -513,15 +513,20 @@ export const advancedSettingsLabel = (): string => intl.formatMessage({
 	defaultMessage: 'Advanced'
 });
 
-// export const audioInputDeviceLabel = (): string => intl.formatMessage({
-// 	id: 'settings.audioInput',
-// 	defaultMessage: 'Audio input device'
-// });
+export const audioInputDeviceLabel = (): string => intl.formatMessage({
+	id: 'settings.audioInput',
+	defaultMessage: 'Audio input device'
+});
 
-// export const audioOutputDeviceLabel = (): string => intl.formatMessage({
-// 	id: 'settings.audioOutput',
-// 	defaultMessage: 'Audio output device'
-// });
+export const audioOutputDeviceLabel = (): string => intl.formatMessage({
+	id: 'settings.audioOutput',
+	defaultMessage: 'Audio output device'
+});
+
+export const testAudioOutputLabel = (): string => intl.formatMessage({
+	id: 'settings.testAudioOutput',
+	defaultMessage: 'Test Audio output'
+});
 
 export const tryToLoadAudioDevices = (): string => intl.formatMessage({
 	id: 'settings.tryToLoadAudioDevices',
@@ -536,11 +541,6 @@ export const selectAudioInputDeviceLabel = (): string => intl.formatMessage({
 export const selectAudioOutputDeviceLabel = (): string => intl.formatMessage({
 	id: 'settings.selectAudioOutput',
 	defaultMessage: 'Select audio output device'
-});
-
-export const audioDeviceLabel = (): string => intl.formatMessage({
-	id: 'settings.audio',
-	defaultMessage: 'Audio input device'
 });
 
 export const noAudioInputDevicesLabel = (): string => intl.formatMessage({

--- a/src/store/selectors.tsx
+++ b/src/store/selectors.tsx
@@ -27,6 +27,12 @@ const headlessSelector: Selector<boolean | undefined> = (state) => state.room.he
 
 export const isMobileSelector: Selector<boolean> = (state) => state.me.browser.platform === 'mobile';
 
+export const canSelectAudioOutput: Selector<boolean> = (state) => {
+	const { name, version } = state.me.browser;
+
+	return name === 'chrome' && Number.parseInt(version) >= 110 && 'setSinkId' in HTMLAudioElement.prototype;
+};
+
 /**
  * Returns the peers as an array.
  * 

--- a/src/store/slices/notificationsSlice.tsx
+++ b/src/store/slices/notificationsSlice.tsx
@@ -28,7 +28,8 @@ const notificationsSlice = createSlice({
 		}),
 		removeNotification: ((state, action: PayloadAction<SnackbarKey>) => {
 			return state.filter((notification) => notification.key !== action.payload);
-		})
+		}),
+		playTestSound: () => {}
 	},
 	extraReducers: (builder) => {
 		builder

--- a/src/store/slices/settingsSlice.tsx
+++ b/src/store/slices/settingsSlice.tsx
@@ -13,6 +13,7 @@ export interface SettingsState {
 	dynamicWidth: boolean;
 	aspectRatio: number;
 	selectedAudioDevice?: string;
+	selectedAudioOutputDevice?: string;
 	selectedVideoDevice?: string;
 	resolution: Resolution;
 	frameRate: number;
@@ -106,6 +107,9 @@ const settingsSlice = createSlice({
 		}),
 		setSelectedAudioDevice: ((state, action: PayloadAction<string | undefined>) => {
 			state.selectedAudioDevice = action.payload;
+		}),
+		setSelectedAudioOutputDevice: ((state, action: PayloadAction<string | undefined>) => {
+			state.selectedAudioOutputDevice = action.payload;
 		}),
 		setSelectedVideoDevice: ((state, action: PayloadAction<string | undefined>) => {
 			state.selectedVideoDevice = action.payload;

--- a/src/utils/types.tsx
+++ b/src/utils/types.tsx
@@ -210,3 +210,8 @@ export interface Dimensions {
 	width: number,
 	height: number
 }
+
+export interface HTMLMediaElementWithSink extends HTMLMediaElement {
+	// eslint-disable-next-line no-unused-vars
+	setSinkId(deviceId: string): Promise<void>
+}

--- a/src/views/join/Join.tsx
+++ b/src/views/join/Join.tsx
@@ -15,6 +15,9 @@ import PrecallTitle from '../../components/precalltitle/PrecallTitle';
 import { ChooserDiv } from '../../components/devicechooser/DeviceChooser';
 import { BlurSwitch } from '../../components/settingsdialog/SettingsSwitches';
 import { meActions } from '../../store/slices/meSlice';
+import AudioOutputChooser from '../../components/devicechooser/AudioOutputChooser';
+import { canSelectAudioOutput } from '../../store/selectors';
+import TestAudioOutputButton from '../../components/audiooutputtest/AudioOutputTest';
 
 interface JoinProps {
 	roomId: string;
@@ -29,6 +32,7 @@ const Join = ({ roomId }: JoinProps): React.JSX.Element => {
 	const mediaLoading = useAppSelector((state) => state.me.videoInProgress || state.me.audioInProgress);
 	const audioMuted = useAppSelector((state) => state.me.audioMuted);
 	const videoMuted = useAppSelector((state) => state.me.videoMuted);
+	const showAudioOutputChooser = useAppSelector(canSelectAudioOutput);
 	
 	const url = new URL(window.location.href);
 	const headless = Boolean(url.searchParams.get('headless'));
@@ -63,7 +67,9 @@ const Join = ({ roomId }: JoinProps): React.JSX.Element => {
 				<>
 					<MediaPreview startAudio={!audioMuted} startVideo={!videoMuted} stopAudio={false} stopVideo={false} />
 					<AudioInputChooser />
+					{showAudioOutputChooser && <AudioOutputChooser /> }
 					<VideoInputChooser />
+					<TestAudioOutputButton />
 					<BlurSwitch />
 					<ChooserDiv>
 						<TextInputField

--- a/src/views/lobby/Lobby.tsx
+++ b/src/views/lobby/Lobby.tsx
@@ -16,6 +16,7 @@ import PrecallTitle from '../../components/precalltitle/PrecallTitle';
 import { ChooserDiv } from '../../components/devicechooser/DeviceChooser';
 import AudioOutputChooser from '../../components/devicechooser/AudioOutputChooser';
 import { canSelectAudioOutput } from '../../store/selectors';
+import TestAudioOutputButton from '../../components/audiooutputtest/AudioOutputTest';
 
 const Lobby = (): React.JSX.Element => {
 	useNotifier();
@@ -39,6 +40,7 @@ const Lobby = (): React.JSX.Element => {
 					<MediaPreview />
 					<AudioInputChooser />
 					{showAudioOutputChooser && <AudioOutputChooser /> }
+					<TestAudioOutputButton />
 					<VideoInputChooser />
 					<ChooserDiv>
 						<TextInputField

--- a/src/views/lobby/Lobby.tsx
+++ b/src/views/lobby/Lobby.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../store/hooks';
 import PrecallTitle from '../../components/precalltitle/PrecallTitle';
 import { ChooserDiv } from '../../components/devicechooser/DeviceChooser';
+import AudioOutputChooser from '../../components/devicechooser/AudioOutputChooser';
+import { canSelectAudioOutput } from '../../store/selectors';
 
 const Lobby = (): React.JSX.Element => {
 	useNotifier();
@@ -21,6 +23,7 @@ const Lobby = (): React.JSX.Element => {
 	const dispatch = useAppDispatch();
 	const displayName = useAppSelector((state) => state.settings.displayName);
 	const [ localDisplayName, setLocalDisplayName ] = useState(displayName);
+	const showAudioOutputChooser = useAppSelector(canSelectAudioOutput);
 
 	const handleDisplayNameChange = () => {
 		dispatch(setDisplayName(
@@ -35,6 +38,7 @@ const Lobby = (): React.JSX.Element => {
 				<>
 					<MediaPreview />
 					<AudioInputChooser />
+					{showAudioOutputChooser && <AudioOutputChooser /> }
 					<VideoInputChooser />
 					<ChooserDiv>
 						<TextInputField


### PR DESCRIPTION
closes #163 

This PR will add support for selecting audio output and testing audio output by playing notification sound.

I'm suggesting we only add support for Chrome version > 110.
That is what Google Meet is doing.

Echo cancellation breaks in Firefox when using `setSinkId()`.
There may be other problems in other browsers.