### PR TITLE
Change default value for max active videos from 0 to 12 when creating new rooms via mgmt interface

### DIFF
--- a/src/components/managementservice/rooms/Room.tsx
+++ b/src/components/managementservice/rooms/Room.tsx
@@ -297,7 +297,7 @@ const RoomTable = () => {
 		setDefaultRoleIdOption(undefined);
 		setLogo('');
 		setBackground('');
-		setMaxActiveVideos(0);
+		setMaxActiveVideos(12);
 		setLocked(true);
 		setChatEnabled(true);
 		setRaiseHandEnabled(true);


### PR DESCRIPTION
Prevents users from creating non-functional rooms.