### PR TITLE
feat: Add configurable option to open infoTooltipLink in new window

### DIFF
--- a/public/config/config.example.js
+++ b/public/config/config.example.js
@@ -109,6 +109,7 @@ var config = {
 	infoTooltipText: '',
 	infoTooltipDesc: '',
 	infoTooltipLink: '',
+	infoTooltipLinkNewWindow: false,
 
 	/**
 	 * Optional: show imprint/privacy links (blank hides them).

--- a/src/components/genericdialog/GenericDialog.tsx
+++ b/src/components/genericdialog/GenericDialog.tsx
@@ -80,6 +80,7 @@ const GenericDialog = ({
 	const infoTooltipEnabled = edumeetConfig.infoTooltipEnabled;
 	const infoTooltipText = edumeetConfig.infoTooltipText;
 	const infoTooltipLink = edumeetConfig.infoTooltipLink;
+	const infoTooltipLinkNewWindow = edumeetConfig.infoTooltipLinkNewWindow;
 	const infoTooltipDesc = edumeetConfig.infoTooltipDesc;
 	
 	return (
@@ -97,7 +98,7 @@ const GenericDialog = ({
 			{infoTooltipEnabled && showFooter && <StyledDialogFooter>
 				<Grid container>
 					<Grid size={12} textAlign={'center'}>
-						{infoTooltipLink!='' ? <Link href={infoTooltipLink}>{ infoTooltipText }</Link> : infoTooltipText }
+						{infoTooltipLink!='' ? <Link href={infoTooltipLink} target={infoTooltipLinkNewWindow ? '_blank' : '_self'}>{ infoTooltipText }</Link> : infoTooltipText }
 					</Grid>
 					{infoTooltipDesc!='' && <Grid size={12} textAlign={'justify'}>
 						{ infoTooltipDesc }

--- a/src/utils/types.tsx
+++ b/src/utils/types.tsx
@@ -8,6 +8,7 @@ export const defaultEdumeetConfig: EdumeetConfig = {
 	infoTooltipEnabled: false,
 	infoTooltipText: '',
 	infoTooltipLink: '',
+	infoTooltipLinkNewWindow: false,
 	infoTooltipDesc: '',
 	managementUrl: undefined,
 	loginImageURL: '',
@@ -137,6 +138,7 @@ export interface EdumeetConfig {
 	infoTooltipEnabled: boolean;
 	infoTooltipText?: string;
 	infoTooltipLink?: string;
+	infoTooltipLinkNewWindow: boolean;
 	infoTooltipDesc?: string;
 	managementUrl?: string;
 	loginImageURL?: string;


### PR DESCRIPTION
Can we have a configurable `infoTooltipLinkNewWindow` option to control if the link opens in a new window?