### PR TITLE
Remove automatic github assignment

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Please fill in the appropriate fields to help us solve your issue
 title: "[BUG]"
 labels: bug
-assignees: havfo, pnts-se
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: "[FEATURE REQUEST]"
 labels: enhancement
-assignees: havfo, pnts-se
 
 ---
 


### PR DESCRIPTION
This made sense at some point, but not so much any longer.