### PR TITLE
 e2ee fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
 		"start": "vite",
 		"build": "tsc && vite build",
 		"serve": "vite preview",
-		"lint": "eslint . --ext .ts,.tsx"
+		"lint": "eslint . --ext .ts,.tsx",
+		"test": "vitest run"
 	},
 	"browserslist": {
 		"production": [
@@ -109,7 +110,8 @@
 		"rollup-plugin-visualizer": "^7.0.1",
 		"vite": "^8.2.0",
 		"vite-plugin-eslint": "^1.8.1",
-		"vite-tsconfig-paths": "^6.1.1"
+		"vite-tsconfig-paths": "^6.1.1",
+		"vitest": "^5.0.0"
 	},
 	"packageManager": "yarn@4.13.0"
 }

--- a/src/services/e2eeService.test.ts
+++ b/src/services/e2eeService.test.ts
@@ -1,0 +1,348 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/deviceInfo', () => ({
+	browserInfo: { getEngineName: () => 'test', getBrowserName: () => 'test', getBrowserVersion: () => '0' },
+}));
+
+import { E2eeService } from './e2eeService';
+import { WebCryptoKeyProvider } from '../utils/e2ee/WebCryptoKeyProvider';
+import { peerNamespace } from '../utils/e2ee/crypto';
+
+// eslint-disable-next-line no-unused-vars
+type Listener = (e: MessageEvent) => void;
+
+class FakeWorker {
+	static instances: FakeWorker[] = [];
+	onmessage: Listener | null = null;
+	readonly posted: Array<Record<string, unknown>> = [];
+
+	constructor() {
+		FakeWorker.instances.push(this);
+	}
+
+	postMessage(message: Record<string, unknown>): void {
+		this.posted.push(message);
+	}
+
+	emit(data: Record<string, unknown>): void {
+		this.onmessage?.({ data } as unknown as MessageEvent);
+	}
+
+	postedOfType(type: string): Array<Record<string, unknown>> {
+		return this.posted.filter((m) => m.type === type);
+	}
+}
+
+class FakeTransform {
+	static instances: FakeTransform[] = [];
+	readonly worker: FakeWorker;
+	readonly options: Record<string, unknown>;
+
+	constructor(worker: FakeWorker, options: Record<string, unknown>) {
+		this.worker = worker;
+		this.options = options;
+		FakeTransform.instances.push(this);
+	}
+}
+
+const diag = (worker: FakeWorker, event: string, extra: Record<string, unknown> = {}): void =>
+	worker.emit({ type: 'e2eeDiag', level: 'debug', event, ...extra });
+
+const sender = (): RTCRtpSender => ({} as unknown as RTCRtpSender);
+const receiver = (): RTCRtpReceiver => ({} as unknown as RTCRtpReceiver);
+
+const enabledService = async () => {
+	const service = new E2eeService();
+
+	await service.enable('me');
+
+	const [ enc, dec ] = FakeWorker.instances;
+
+	return { service, enc, dec };
+};
+
+// Whether a promise has settled, without waiting on it: the waiters here must stay pending until
+// their own confirmation arrives, and a pending promise cannot be asserted on by awaiting it.
+const settled = async (p: Promise<unknown>): Promise<boolean> => {
+	let done = false;
+
+	void p.then(() => { done = true; }, () => { done = true; });
+	await vi.advanceTimersByTimeAsync(0);
+
+	return done;
+};
+
+describe('E2EE service', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		FakeWorker.instances = [];
+		FakeTransform.instances = [];
+		vi.stubGlobal('Worker', FakeWorker);
+		vi.stubGlobal('RTCRtpScriptTransform', FakeTransform);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.unstubAllGlobals();
+	});
+
+	describe('enabling', () => {
+		it('starts two workers and hands the encrypt worker the initial key', async () => {
+			const { service, enc, dec } = await enabledService();
+			const [ first ] = enc.postedOfType('encKey');
+
+			expect(service.enabled).toBe(true);
+			expect(FakeWorker.instances).toHaveLength(2);
+			expect(first.ratcheted).toBe(false);
+			expect((first.keyId as number) >>> 8).toBe(await peerNamespace('me'));
+			expect((first.keyId as number) & 0xff).toBe(0);
+			expect(dec.posted).toEqual([]);
+		});
+
+		it('is idempotent', async () => {
+			const { service } = await enabledService();
+
+			await service.enable('me');
+
+			expect(FakeWorker.instances).toHaveLength(2);
+		});
+	});
+
+	describe('releasing a sender', () => {
+		it('needs nothing when encryption is off', async () => {
+			await expect(new E2eeService().whenProtectionActive(undefined)).resolves.toBe(true);
+		});
+
+		it('refuses when encryption is on but no transform was attached', async () => {
+			const { service } = await enabledService();
+
+			await expect(service.whenProtectionActive(undefined)).resolves.toBe(false);
+		});
+
+		it('releases exactly the producer whose transform confirmed', async () => {
+			const { service, enc } = await enabledService();
+			const camera = await service.protectSender(sender(), 'video/VP8');
+			const mic = await service.protectSender(sender(), 'audio/opus');
+			const cameraReady = service.whenProtectionActive(camera);
+			const micReady = service.whenProtectionActive(mic);
+
+			diag(enc, 'pipeLive', { op: 'encrypt', id: mic });
+
+			expect(await settled(micReady)).toBe(true);
+			expect(await settled(cameraReady)).toBe(false);
+			await expect(micReady).resolves.toBe(true);
+
+			diag(enc, 'pipeLive', { op: 'encrypt', id: camera });
+			await expect(cameraReady).resolves.toBe(true);
+		});
+
+		it('gives up on a transform that never confirms', async () => {
+			const { service } = await enabledService();
+			const tid = await service.protectSender(sender(), 'video/VP8');
+			const ready = service.whenProtectionActive(tid);
+
+			await vi.advanceTimersByTimeAsync(29999);
+			expect(await settled(ready)).toBe(false);
+
+			await vi.advanceTimersByTimeAsync(1);
+			await expect(ready).resolves.toBe(false);
+		});
+
+		it('is not released by the decrypt side or by a message outside the envelope', async () => {
+			const { service, enc, dec } = await enabledService();
+			const tid = await service.protectSender(sender(), 'video/VP8');
+			const ready = service.whenProtectionActive(tid);
+
+			diag(dec, 'pipeLive', { op: 'decrypt', id: tid });
+			enc.emit({ type: 'other', event: 'pipeLive', op: 'encrypt', id: tid });
+
+			expect(await settled(ready)).toBe(false);
+		});
+	});
+
+	describe('watchdog', () => {
+		it('arms only once a transform is attached and media can flow, then fires once', async () => {
+			const { service } = await enabledService();
+			const unverified = vi.fn();
+
+			service.onEncryptionUnverified = unverified;
+
+			service.notifyMediaFlowPossible();
+			await vi.advanceTimersByTimeAsync(3000);
+			expect(unverified).not.toHaveBeenCalled();
+
+			await service.protectSender(sender(), 'video/VP8');
+			await vi.advanceTimersByTimeAsync(2999);
+			expect(unverified).not.toHaveBeenCalled();
+
+			await vi.advanceTimersByTimeAsync(1);
+			expect(unverified).toHaveBeenCalledTimes(1);
+
+			await vi.advanceTimersByTimeAsync(10000);
+			expect(unverified).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not arm for a receive only participant', async () => {
+			const { service } = await enabledService();
+			const unverified = vi.fn();
+
+			service.onEncryptionUnverified = unverified;
+			await service.protectReceiver(receiver(), 'video/VP8');
+			service.notifyMediaFlowPossible();
+			await vi.advanceTimersByTimeAsync(10000);
+
+			expect(unverified).not.toHaveBeenCalled();
+		});
+
+		it('is cancelled by the first confirmed encryption', async () => {
+			const { service, enc } = await enabledService();
+			const unverified = vi.fn();
+
+			service.onEncryptionUnverified = unverified;
+
+			const tid = await service.protectSender(sender(), 'video/VP8');
+
+			service.notifyMediaFlowPossible();
+			await vi.advanceTimersByTimeAsync(1000);
+			diag(enc, 'pipeLive', { op: 'encrypt', id: tid });
+			await vi.advanceTimersByTimeAsync(10000);
+
+			expect(unverified).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('verified state', () => {
+		it('is set once by a first frame in either direction', async () => {
+			const { service, enc, dec } = await enabledService();
+			const verified = vi.fn();
+
+			service.onEncryptionVerified = verified;
+
+			expect(service.encryptionVerified).toBe(false);
+
+			diag(dec, 'firstFrame', { op: 'decrypt' });
+			expect(service.encryptionVerified).toBe(true);
+			expect(verified).toHaveBeenCalledTimes(1);
+
+			diag(enc, 'firstFrame', { op: 'encrypt' });
+			expect(verified).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('attaching transforms', () => {
+		it('binds encrypt to the first worker and decrypt to the second, with a normalised codec', async () => {
+			const { service, enc, dec } = await enabledService();
+
+			await service.protectSender(sender(), 'video/VP9');
+			await service.protectSender(sender(), 'video/H264');
+			await service.protectSender(sender(), 'audio/PCMU');
+			await service.protectSender(sender(), 'video/AV1');
+			await service.protectReceiver(receiver(), 'audio/opus');
+
+			const [ vp9, h264, pcmu, av1, opus ] = FakeTransform.instances;
+
+			expect(vp9.worker).toBe(enc);
+			expect(vp9.options).toMatchObject({ operation: 'encrypt', codec: 'vp9' });
+			expect(h264.options.codec).toBe('h264');
+			expect(pcmu.options.codec).toBe('opus');
+			expect(av1.options.codec).toBe('unknown');
+			expect(opus.worker).toBe(dec);
+			expect(opus.options).toMatchObject({ operation: 'decrypt', codec: 'opus' });
+			expect(new Set(FakeTransform.instances.map((t) => t.options.tid)).size).toBe(5);
+		});
+
+		it('attaches nothing when disabled or when there is no target', async () => {
+			expect(await new E2eeService().protectSender(sender(), 'video/VP8')).toBeUndefined();
+
+			const { service } = await enabledService();
+
+			expect(await service.protectSender(undefined, 'video/VP8')).toBeUndefined();
+			expect(FakeTransform.instances).toHaveLength(0);
+		});
+	});
+
+	describe('advancing the local key', () => {
+		it('only advances once something was encrypted under the current key', async () => {
+			const { service, enc } = await enabledService();
+			const keyIdOf = (index: number): number => enc.postedOfType('encKey')[index].keyId as number;
+
+			await service.ratchetLocalKey();
+			expect(enc.postedOfType('encKey')).toHaveLength(1);
+
+			diag(enc, 'encKeyUsed', { keyId: keyIdOf(0) });
+			await service.ratchetLocalKey();
+			expect(enc.postedOfType('encKey')).toHaveLength(2);
+			expect(enc.postedOfType('encKey')[1].ratcheted).toBe(true);
+			expect(keyIdOf(1) & 0xff).toBe(1);
+
+			diag(enc, 'encKeyUsed', { keyId: keyIdOf(0) });
+			await service.ratchetLocalKey();
+			expect(enc.postedOfType('encKey')).toHaveLength(2);
+
+			diag(enc, 'encKeyUsed', { keyId: keyIdOf(1) });
+			await service.ratchetLocalKey();
+			expect(enc.postedOfType('encKey')).toHaveLength(3);
+		});
+
+		it('replaces the key on rotate regardless and starts the count over', async () => {
+			const { service, enc } = await enabledService();
+
+			await service.rotateLocalKey();
+
+			const [ , replaced ] = enc.postedOfType('encKey');
+
+			expect(replaced.ratcheted).toBe(false);
+			expect((replaced.keyId as number) & 0xff).toBe(1);
+
+			await service.ratchetLocalKey();
+			expect(enc.postedOfType('encKey')).toHaveLength(2);
+		});
+	});
+
+	describe('peers', () => {
+		it('asks for a key only for a namespace that belongs to a known peer', async () => {
+			const { service, dec } = await enabledService();
+			const bob = new WebCryptoKeyProvider('bob');
+			const needed = vi.fn();
+
+			await bob.init();
+			await service.addPeer('bob', await bob.getIdentityPublicKey());
+			service.onKeyNeeded = needed;
+
+			const namespace = await peerNamespace('bob');
+
+			diag(dec, 'keyNeeded', { namespace });
+			expect(needed).toHaveBeenCalledWith('bob');
+
+			diag(dec, 'keyNeeded', { namespace: 0x123456 });
+			expect(needed).toHaveBeenCalledTimes(1);
+
+			service.removePeer('bob');
+			await vi.advanceTimersByTimeAsync(0);
+			diag(dec, 'keyNeeded', { namespace });
+
+			expect(needed).toHaveBeenCalledTimes(1);
+			expect(dec.postedOfType('dropKeys')).toEqual([ { type: 'dropKeys', namespace } ]);
+		});
+
+		it('hands an unwrapped remote key, with its bytes, to the decrypt worker', async () => {
+			const { service, dec } = await enabledService();
+			const bob = new WebCryptoKeyProvider('bob');
+
+			await bob.init();
+			await bob.addPeer('me', await service.getIdentityPublicKey());
+			await service.addPeer('bob', await bob.getIdentityPublicKey());
+
+			const msg = await bob.wrapLocalKeyFor('me');
+
+			await service.onRemoteKey('bob', msg.keyId, msg.iv, msg.data);
+
+			const [ delivered ] = dec.postedOfType('decKey');
+
+			expect(delivered.keyId).toBe(msg.keyId);
+			expect((delivered.key as CryptoKey).algorithm.name).toBe('AES-GCM');
+			expect(delivered.raw).toBeInstanceOf(Uint8Array);
+			expect((delivered.raw as Uint8Array).length).toBe(32);
+		});
+	});
+});

--- a/src/services/e2eeService.test.ts
+++ b/src/services/e2eeService.test.ts
@@ -345,4 +345,66 @@ describe('E2EE service', () => {
 			expect((delivered.raw as Uint8Array).length).toBe(32);
 		});
 	});
+
+	describe('a key burned by a departure while nothing was being sent', () => {
+		it('is replaced before the next producer attaches its transform', async () => {
+			const { service } = await enabledService();
+			const order: string[] = [];
+
+			service.onRotateRequired = async () => {
+				order.push(`rotate with ${FakeTransform.instances.length} transforms attached`);
+			};
+			service.markKeyBurned();
+
+			await service.protectSender(sender(), 'audio/opus');
+
+			expect(order).toEqual([ 'rotate with 0 transforms attached' ]);
+			expect(FakeTransform.instances).toHaveLength(1);
+		});
+
+		it('is replaced once when several producers start together', async () => {
+			const { service } = await enabledService();
+			const rotate = vi.fn(async () => undefined);
+
+			service.onRotateRequired = rotate;
+			service.markKeyBurned();
+
+			await Promise.all([
+				service.protectSender(sender(), 'audio/opus'),
+				service.protectSender(sender(), 'video/VP8'),
+				service.protectSender(sender(), 'video/VP8'),
+			]);
+
+			expect(rotate).toHaveBeenCalledTimes(1);
+			expect(FakeTransform.instances).toHaveLength(3);
+		});
+
+		it('does not replace an unburned key, and a replacement clears the burn', async () => {
+			const { service } = await enabledService();
+			const rotate = vi.fn(async () => undefined);
+
+			service.onRotateRequired = rotate;
+
+			await service.protectSender(sender(), 'audio/opus');
+			expect(rotate).not.toHaveBeenCalled();
+
+			service.markKeyBurned();
+			await service.rotateLocalKey();
+			await service.protectSender(sender(), 'video/VP8');
+			expect(rotate).not.toHaveBeenCalled();
+		});
+
+		it('still replaces the key locally when nothing is wired to distribute it', async () => {
+			const { service, enc } = await enabledService();
+
+			service.markKeyBurned();
+			await service.protectSender(sender(), 'audio/opus');
+
+			const keys = enc.postedOfType('encKey');
+
+			expect(keys).toHaveLength(2);
+			expect(keys[1].ratcheted).toBe(false);
+			expect((keys[1].keyId as number) & 0xff).toBe(1);
+		});
+	});
 });

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -105,6 +105,39 @@ export class E2eeService {
 	readonly #namespaces = new Map<number, string>(); // media key namespace -> peerId
 	#localKeyUsed = false; // has anything been encrypted under the key we currently hold
 
+	// A departure happened while we had no producer. The leaver holds our key, so it has to be replaced
+	// before we send anything, but with nothing to send there is no reason to do it yet, and in a large
+	// room most participants have nothing to send. It is replaced when the next producer starts, before
+	// that producer's transform is attached, so no frame ever leaves under the burned key.
+	#keyBurned = false;
+	#burnedRotation?: Promise<void>;
+
+	// Set by the middleware, which is the only party that can distribute the replacement.
+	onRotateRequired?: () => Promise<void>;
+
+	markKeyBurned(): void {
+		this.#keyBurned = true;
+	}
+
+	#rotateIfBurned(): Promise<void> {
+		if (!this.#keyBurned) return Promise.resolve();
+
+		// Several producers starting together must share one replacement, not race three.
+		if (!this.#burnedRotation) {
+			this.#burnedRotation = (async () => {
+				this.#keyBurned = false;
+
+				// Without the middleware the key is still replaced; recipients recover it by asking.
+				if (this.onRotateRequired) await this.onRotateRequired();
+				else await this.rotateLocalKey();
+			})().finally(() => {
+				this.#burnedRotation = undefined;
+			});
+		}
+
+		return this.#burnedRotation;
+	}
+
 	// A peer whose media we cannot decrypt, either because their key never reached us or because we
 	// have fallen too far behind their advances. The worker only sees namespaces, so the peer is
 	// resolved here and the caller decides how to ask.
@@ -220,6 +253,7 @@ export class E2eeService {
 	async protectSender(sender?: RTCRtpSender, codecMime?: string): Promise<number | undefined> {
 		if (!this.#enabled || !sender) return undefined;
 		await this.#ready;
+		await this.#rotateIfBurned();
 
 		return this.#attach(sender, 'encrypt', codecMime);
 	}
@@ -296,6 +330,7 @@ export class E2eeService {
 	}
 
 	async rotateLocalKey(): Promise<void> {
+		this.#keyBurned = false;
 		await this.#provider!.rotateLocalKey();
 		this.#pushLocalKey();
 	}

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -102,6 +102,15 @@ export class E2eeService {
 	// Fired once, when a frame has demonstrably been encrypted or decrypted.
 	onEncryptionVerified?: () => void;
 
+	readonly #namespaces = new Map<number, string>(); // media key namespace -> peerId
+	#localKeyUsed = false; // has anything been encrypted under the key we currently hold
+
+	// A peer whose media we cannot decrypt, either because their key never reached us or because we
+	// have fallen too far behind their advances. The worker only sees namespaces, so the peer is
+	// resolved here and the caller decides how to ask.
+	// eslint-disable-next-line no-unused-vars
+	onKeyNeeded?: (peerId: string) => void;
+
 	get encryptionVerified(): boolean {
 		return this.#encryptVerified;
 	}
@@ -162,6 +171,16 @@ export class E2eeService {
 				this.#protectionActive = true;
 				if (this.#verifyTimer) clearTimeout(this.#verifyTimer);
 			}
+		}
+
+		if (d.event === 'encKeyUsed' && (d.keyId >>> 0) === this.#provider?.localKey()?.keyId) this.#localKeyUsed = true;
+
+		if (d.event === 'keyNeeded') {
+			const peerId = this.#namespaces.get(d.namespace >>> 0);
+
+			// An unknown namespace is not a peer: a clear-byte disagreement parses ciphertext as a
+			// header and produces key identifiers that belong to nobody. Nothing to ask, so ignore it.
+			if (peerId) this.onKeyNeeded?.(peerId);
 		}
 
 		// Either direction counts here: successfully decrypting a peer proves the crypto is working just
@@ -243,8 +262,12 @@ export class E2eeService {
 		return this.#provider?.hasPeer(peerId) ?? false;
 	}
 
-	addPeer(peerId: string, identityPubKey: Bytes): Promise<IdentityStatus> {
-		return this.#provider!.addPeer(peerId, identityPubKey);
+	async addPeer(peerId: string, identityPubKey: Bytes): Promise<IdentityStatus> {
+		const status = await this.#provider!.addPeer(peerId, identityPubKey);
+
+		this.#namespaces.set(await peerNamespace(peerId), peerId);
+
+		return status;
 	}
 
 	removePeer(peerId: string): void {
@@ -252,7 +275,14 @@ export class E2eeService {
 
 		// The worker holds this peer's media keys and knows nothing about peers, so tell it to drop
 		// them. Otherwise they stay valid for the rest of the session and old frames remain replayable.
-		void peerNamespace(peerId).then((namespace) => this.#decWorker?.postMessage({ type: 'dropKeys', namespace }));
+		// The namespace was recorded when the peer was added, so this needs no await: hashing it again
+		// would leave a gap in which a request for a key could still name a peer who has gone.
+		for (const [ namespace, id ] of this.#namespaces) {
+			if (id !== peerId) continue;
+
+			this.#namespaces.delete(namespace);
+			this.#decWorker?.postMessage({ type: 'dropKeys', namespace });
+		}
 	}
 
 	wrapLocalKeyFor(peerId: string): Promise<WrappedKeyMessage> {
@@ -268,15 +298,31 @@ export class E2eeService {
 		this.#pushLocalKey();
 	}
 
+	// Advancing hides what was sent before a newcomer arrived. With nothing sent under the current key
+	// there is nothing to hide, and advancing anyway would only put us further ahead of the peers who
+	// have had no frames from us to follow, which is exactly the participant this protects: mic and
+	// camera off through a run of arrivals, then unmuting into a room that can no longer read them.
+	async ratchetLocalKey(): Promise<void> {
+		if (!this.#localKeyUsed) {
+			logger.debug('nothing sent under the current key, keeping it rather than advancing');
+
+			return;
+		}
+
+		await this.#provider!.ratchetLocalKey();
+		this.#pushLocalKey(true);
+	}
+
 	async onRemoteKey(fromPeerId: string, keyId: number, iv: Bytes, data: ArrayBuffer): Promise<void> {
 		const update = await this.#provider!.unwrapRemoteKey(fromPeerId, keyId, iv, data);
 
-		this.#decWorker?.postMessage({ type: 'decKey', keyId: update.keyId, key: update.key });
+		this.#decWorker?.postMessage({ type: 'decKey', keyId: update.keyId, key: update.key, raw: update.raw });
 	}
 
-	#pushLocalKey(): void {
+	#pushLocalKey(ratcheted = false): void {
 		const lk: LocalKey | undefined = this.#provider?.localKey();
 
-		if (lk) this.#encWorker?.postMessage({ type: 'encKey', keyId: lk.keyId, key: lk.key });
+		this.#localKeyUsed = false;
+		if (lk) this.#encWorker?.postMessage({ type: 'encKey', keyId: lk.keyId, key: lk.key, ratcheted });
 	}
 }

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -319,7 +319,8 @@ export class E2eeService {
 		const update = await this.#provider!.unwrapRemoteKey(fromPeerId, keyId, iv, data);
 
 		// Logged here as well as in the worker so a gap between the two can be attributed to one side.
-		logger.debug('remote key unwrapped, handing it to the worker [keyId:%d]', update.keyId);
+		// Formatted as a string: the browser console's own %d renders a key id above 2^31 as negative.
+		logger.debug('remote key unwrapped, handing it to the worker [keyId:%s]', String(update.keyId));
 		this.#decWorker?.postMessage({ type: 'decKey', keyId: update.keyId, key: update.key, raw: update.raw });
 	}
 

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -15,6 +15,16 @@ const logger = new Logger('E2eeService');
 // room that will not work, not how long plaintext escapes.
 const ENCRYPTION_VERIFY_MS = 3000;
 
+// Upper bound on how long a sender waits for its own transform to confirm before giving up on that
+// stream. This is a hang guard, not a security bound: the guarantee comes from never enabling the
+// track without confirmation, so this only has to stop an await lasting forever. It is deliberately
+// generous, because the wait starts before the transport connects and a slow ICE negotiation must
+// never be mistaken for a browser that refuses to encrypt.
+const PROTECTION_WAIT_MS = 30000;
+
+// eslint-disable-next-line no-unused-vars
+type ProtectionWaiter = (confirmed: boolean) => void;
+
 // Never fall back to 'opus' for an unrecognised mimeType: the worker splits audio at 1 clear byte
 // and video at 3 or 10, so mislabelling a video stream as audio desynchronises encrypt from decrypt
 // and every frame is dropped with no error. An unknown codec gets its own value, which lands on the
@@ -77,10 +87,11 @@ export class E2eeService {
 	#protectionActive = false;
 	#transformAttached = false;
 	#mediaFlowPossible = false;
-	#protectionResolve?: () => void;
-	// Resolves once an encrypt transform has actually handled a frame. The sender awaits this before
-	// releasing real media, so nothing unprotected is ever sent, not even for the watchdog's window.
-	#protectionPromise = new Promise<void>((resolve) => { this.#protectionResolve = resolve; });
+	#tidSeq = 0;
+	// transform id -> the sender waiting for that specific transform to prove it is handling frames.
+	// This is per transform on purpose: a single shared promise would release a later producer, a
+	// screen share say, on confirmation that belonged to the first one.
+	#pendingProtection = new Map<number, ProtectionWaiter>();
 	#verifyTimer?: ReturnType<typeof setTimeout>;
 	#unverifiedReported = false;
 
@@ -95,8 +106,23 @@ export class E2eeService {
 		return this.#encryptVerified;
 	}
 
-	whenProtectionActive(): Promise<void> {
-		return this.#protectionPromise;
+	// Resolves true once THIS transform has handled a frame, false if it never does. A sender must not
+	// release real media on anything less.
+	whenProtectionActive(tid?: number): Promise<boolean> {
+		if (!this.#enabled || typeof tid !== 'number') return Promise.resolve(true);
+
+		return new Promise<boolean>((resolve) => {
+			const timer = setTimeout(() => {
+				this.#pendingProtection.delete(tid);
+				logger.error('E2EE transform never handled a frame, leaving the track disabled [tid:%d]', tid);
+				resolve(false);
+			}, PROTECTION_WAIT_MS);
+
+			this.#pendingProtection.set(tid, (confirmed) => {
+				clearTimeout(timer);
+				resolve(confirmed);
+			});
+		});
 	}
 
 	// Called when the sending transport connects, i.e. the first moment a frame could reach the
@@ -112,10 +138,20 @@ export class E2eeService {
 
 		if (d?.type !== 'e2eeDiag') return;
 
-		if (d.event === 'pipeLive' && d.op === 'encrypt' && !this.#protectionActive) {
-			this.#protectionActive = true;
-			if (this.#verifyTimer) clearTimeout(this.#verifyTimer);
-			this.#protectionResolve?.();
+		if (d.event === 'pipeLive' && d.op === 'encrypt') {
+			const waiter = this.#pendingProtection.get(d.id);
+
+			if (waiter) {
+				this.#pendingProtection.delete(d.id);
+				waiter(true);
+			}
+
+			// The watchdog only asks whether this browser encrypts at all, so the first confirmation
+			// settles it; a later transform that stalls is handled by its own waiter above.
+			if (!this.#protectionActive) {
+				this.#protectionActive = true;
+				if (this.#verifyTimer) clearTimeout(this.#verifyTimer);
+			}
 		}
 
 		// Either direction counts here: successfully decrypting a peer proves the crypto is working just
@@ -150,37 +186,42 @@ export class E2eeService {
 	}
 
 	// ---- media pipeline: attach transforms ----
-	async protectSender(sender?: RTCRtpSender, codecMime?: string): Promise<void> {
-		if (!this.#enabled || !sender) return;
+	async protectSender(sender?: RTCRtpSender, codecMime?: string): Promise<number | undefined> {
+		if (!this.#enabled || !sender) return undefined;
 		await this.#ready;
-		this.#attach(sender, 'encrypt', codecMime);
+
+		return this.#attach(sender, 'encrypt', codecMime);
 	}
 
-	async protectReceiver(receiver?: RTCRtpReceiver, codecMime?: string): Promise<void> {
-		if (!this.#enabled || !receiver) return;
+	async protectReceiver(receiver?: RTCRtpReceiver, codecMime?: string): Promise<number | undefined> {
+		if (!this.#enabled || !receiver) return undefined;
 		await this.#ready;
-		this.#attach(receiver, 'decrypt', codecMime);
+
+		return this.#attach(receiver, 'decrypt', codecMime);
 	}
 
-	#attach(target: RTCRtpSender | RTCRtpReceiver, operation: 'encrypt' | 'decrypt', codecMime?: string): void {
+	#attach(target: RTCRtpSender | RTCRtpReceiver, operation: 'encrypt' | 'decrypt', codecMime?: string): number | undefined {
 		const worker = operation === 'encrypt' ? this.#encWorker : this.#decWorker;
 
-		if (!worker) return;
+		if (!worker) return undefined;
 
 		// RTCRtpScriptTransform / .transform are not in the DOM lib version here — use loose typing.
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const Transform = (globalThis as any).RTCRtpScriptTransform;
+		const tid = ++this.#tidSeq;
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		(target as any).transform = new Transform(worker, { operation, codec: normalizeCodec(codecMime) });
+		(target as any).transform = new Transform(worker, { operation, codec: normalizeCodec(codecMime), tid });
 
-		logger.debug('E2EE %s transform attached [codec: %s] — awaiting confirmation that frames are actually encrypted',
-			operation, normalizeCodec(codecMime));
+		logger.debug('E2EE %s transform attached [tid:%d, codec:%s] — awaiting confirmation that frames are actually encrypted',
+			operation, tid, normalizeCodec(codecMime));
 
 		if (operation === 'encrypt') {
 			this.#transformAttached = true;
 			this.#startEncryptionWatchdog();
 		}
+
+		return tid;
 	}
 
 	// ---- signaling middleware: key exchange delegation ----

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -109,7 +109,17 @@ export class E2eeService {
 	// Resolves true once THIS transform has handled a frame, false if it never does. A sender must not
 	// release real media on anything less.
 	whenProtectionActive(tid?: number): Promise<boolean> {
-		if (!this.#enabled || typeof tid !== 'number') return Promise.resolve(true);
+		// Nothing to wait for when E2EE is off: senders in that case never hold their track anyway.
+		if (!this.#enabled) return Promise.resolve(true);
+
+		// With E2EE on, no transform id means no transform was attached, which is a failure and must
+		// not read as success. Returning true here would release real media with nothing protecting it,
+		// which is the fail-open this whole design exists to avoid.
+		if (typeof tid !== 'number') {
+			logger.error('E2EE is on but no transform was attached, refusing to release media');
+
+			return Promise.resolve(false);
+		}
 
 		return new Promise<boolean>((resolve) => {
 			const timer = setTimeout(() => {

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -1,6 +1,6 @@
 import { WebCryptoKeyProvider } from '../utils/e2ee/WebCryptoKeyProvider';
 import { IdentityStatus, LocalKey, WrappedKeyMessage } from '../utils/e2ee/E2eeKeyProvider';
-import { Bytes } from '../utils/e2ee/crypto';
+import { Bytes, peerNamespace } from '../utils/e2ee/crypto';
 import { Logger } from '../utils/Logger';
 import { browserInfo } from '../utils/deviceInfo';
 
@@ -239,6 +239,10 @@ export class E2eeService {
 
 	removePeer(peerId: string): void {
 		this.#provider?.removePeer(peerId);
+
+		// The worker holds this peer's media keys and knows nothing about peers, so tell it to drop
+		// them. Otherwise they stay valid for the rest of the session and old frames remain replayable.
+		void peerNamespace(peerId).then((namespace) => this.#decWorker?.postMessage({ type: 'dropKeys', namespace }));
 	}
 
 	wrapLocalKeyFor(peerId: string): Promise<WrappedKeyMessage> {

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -318,6 +318,8 @@ export class E2eeService {
 	async onRemoteKey(fromPeerId: string, keyId: number, iv: Bytes, data: ArrayBuffer): Promise<void> {
 		const update = await this.#provider!.unwrapRemoteKey(fromPeerId, keyId, iv, data);
 
+		// Logged here as well as in the worker so a gap between the two can be attributed to one side.
+		logger.debug('remote key unwrapped, handing it to the worker [keyId:%d]', update.keyId);
 		this.#decWorker?.postMessage({ type: 'decKey', keyId: update.keyId, key: update.key, raw: update.raw });
 	}
 

--- a/src/services/e2eeService.tsx
+++ b/src/services/e2eeService.tsx
@@ -196,8 +196,10 @@ export class E2eeService {
 		const { type, level, ...rest } = d;
 
 		void type;
-		if (level === 'warn') logger.warn('E2EE worker %o', rest);
-		else logger.debug('E2EE worker %o', rest);
+		// JSON rather than an object: the console only sometimes inlines an object into the text it
+		// saves, and a report written as the word "Object" is a report lost.
+		if (level === 'warn') logger.warn('E2EE worker %j', rest);
+		else logger.debug('E2EE worker %j', rest);
 	};
 
 	#startEncryptionWatchdog(): void {

--- a/src/store/middlewares/e2eeMiddleware.test.ts
+++ b/src/store/middlewares/e2eeMiddleware.test.ts
@@ -311,4 +311,24 @@ describe('E2EE middleware', () => {
 		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
 		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
 	});
+
+	it('never hands a newcomer the key from before the advance, even when their reply lands inside the batch window', async () => {
+		const { signaling, service } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await vi.advanceTimersByTimeAsync(150);
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(keysSentTo(signaling)).toEqual([]);
+		expect(service.ratchetLocalKey).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(50);
+
+		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(keysSentTo(signaling)).toEqual([ 'bob', 'bob' ]);
+	});
 });

--- a/src/store/middlewares/e2eeMiddleware.test.ts
+++ b/src/store/middlewares/e2eeMiddleware.test.ts
@@ -67,15 +67,18 @@ const makeService = (enabled: boolean) => {
 		ratchetLocalKey: vi.fn(async () => undefined),
 		onRemoteKey: vi.fn(async () => undefined),
 		enable: vi.fn(async () => undefined),
+		markKeyBurned: vi.fn(),
+		onRotateRequired: undefined as (() => Promise<void>) | undefined,
 		onKeyNeeded: undefined as PeerCallback | undefined,
 		onEncryptionVerified: undefined as (() => void) | undefined,
 		onEncryptionUnverified: undefined as (() => void) | undefined,
 	};
 };
 
-const setup = ({ e2eeEnabled = true, serviceEnabled = true } = {}) => {
+const setup = ({ e2eeEnabled = true, serviceEnabled = true, producers = true } = {}) => {
 	const signaling = makeSignaling();
 	const service = makeService(serviceEnabled);
+	const mediaService = { mediaSenders: { mic: producers ? { producer: {} } : {}, webcam: {} } };
 	const dispatch = vi.fn();
 	const next = vi.fn((action: unknown) => action);
 	const getState = () => ({
@@ -83,7 +86,7 @@ const setup = ({ e2eeEnabled = true, serviceEnabled = true } = {}) => {
 		me: { id: 'me' },
 		peers: { bob: { displayName: 'Bob' } },
 	});
-	const run = createE2eeMiddleware({ signalingService: signaling, e2eeService: service } as unknown as MiddlewareInput)(
+	const run = createE2eeMiddleware({ signalingService: signaling, e2eeService: service, mediaService } as unknown as MiddlewareInput)(
 		{ dispatch, getState } as unknown as ApiInput
 	)(next);
 
@@ -218,6 +221,10 @@ describe('E2EE middleware', () => {
 		run(peersActions.removePeer({ id: 'bob' }));
 		await vi.advanceTimersByTimeAsync(0);
 
+		expect(service.rotateLocalKey).not.toHaveBeenCalled();
+
+		await vi.advanceTimersByTimeAsync(200);
+
 		expect(service.removePeer).toHaveBeenCalledWith('bob');
 		expect(dispatch).toHaveBeenCalledWith(e2eeActions.removePeer({ peerId: 'bob' }));
 		expect(service.rotateLocalKey).toHaveBeenCalledTimes(1);
@@ -298,7 +305,7 @@ describe('E2EE middleware', () => {
 		await signaling.deliver('e2eeIdentity', identity('bob'));
 		await vi.advanceTimersByTimeAsync(200);
 		run(peersActions.removePeer({ id: 'bob' }));
-		await vi.advanceTimersByTimeAsync(0);
+		await vi.advanceTimersByTimeAsync(200);
 		signaling.notify.mockClear();
 		service.ratchetLocalKey.mockClear();
 
@@ -330,5 +337,46 @@ describe('E2EE middleware', () => {
 		await signaling.deliver('e2eeIdentity', identity('bob'));
 
 		expect(keysSentTo(signaling)).toEqual([ 'bob', 'bob' ]);
+	});
+
+	it('replaces its key once for several peers leaving inside the batch window', async () => {
+		const { signaling, service, run } = setup();
+
+		for (const id of [ 'bob', 'carol', 'dave' ]) await signaling.deliver('e2eeIdentity', identity(id));
+		await vi.advanceTimersByTimeAsync(200);
+		signaling.notify.mockClear();
+
+		run(peersActions.removePeer({ id: 'bob' }));
+		await vi.advanceTimersByTimeAsync(100);
+		run(peersActions.removePeer({ id: 'carol' }));
+		await vi.advanceTimersByTimeAsync(100);
+
+		expect(service.rotateLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([ 'dave' ]);
+
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(service.rotateLocalKey).toHaveBeenCalledTimes(1);
+	});
+
+	it('only marks the key burned while it has no producer, and replaces it when one starts', async () => {
+		const { signaling, service, run } = setup({ producers: false });
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await signaling.deliver('e2eeIdentity', identity('carol'));
+		await vi.advanceTimersByTimeAsync(200);
+		signaling.notify.mockClear();
+
+		run(peersActions.removePeer({ id: 'bob' }));
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(service.markKeyBurned).toHaveBeenCalledTimes(1);
+		expect(service.rotateLocalKey).not.toHaveBeenCalled();
+		expect(keysSentTo(signaling)).toEqual([]);
+
+		await service.onRotateRequired!();
+
+		expect(service.rotateLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([ 'carol' ]);
 	});
 });

--- a/src/store/middlewares/e2eeMiddleware.test.ts
+++ b/src/store/middlewares/e2eeMiddleware.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../utils/edumeetConfig', () => ({ default: { theme: {}, simulcast: true, simulcastSharing: true } }));
+vi.mock('../../services/mediaService', () => ({}));
+vi.mock('../store', () => ({}));
+vi.mock('../selectors', () => ({ isInsertableStreamsSupported: () => true }));
+vi.mock('./roomMiddleware', () => ({ JOIN_ERROR_KEY: 'joinError' }));
+vi.mock('../../components/translated/translatedComponents', () => ({
+	peerIdentityChangedLabel: (peer: string) => `identity changed ${peer}`,
+	roomE2eeFailedLabel: () => 'e2ee failed',
+	peerSentReactionLabel: () => 'reaction',
+}));
+
+import createE2eeMiddleware from './e2eeMiddleware';
+import { signalingActions } from '../slices/signalingSlice';
+import { roomActions } from '../slices/roomSlice';
+import { peersActions } from '../slices/peersSlice';
+import { e2eeActions } from '../slices/e2eeSlice';
+import { notificationsActions } from '../slices/notificationsSlice';
+import { toB64 } from '../../utils/e2ee/crypto';
+
+type SignalingNotification = { method: string; data: Record<string, unknown> };
+// eslint-disable-next-line no-unused-vars
+type NotificationHandler = (notification: SignalingNotification) => Promise<void> | void;
+// eslint-disable-next-line no-unused-vars
+type PeerCallback = (peerId: string) => void;
+type MiddlewareInput = Parameters<typeof createE2eeMiddleware>[0];
+type ApiInput = Parameters<ReturnType<typeof createE2eeMiddleware>>[0];
+
+const PUB = toB64(new Uint8Array(65));
+
+const makeSignaling = () => {
+	let handler: NotificationHandler | undefined;
+
+	return {
+		notify: vi.fn(),
+		on: vi.fn((event: string, cb: NotificationHandler) => {
+			if (event === 'notification') handler = cb;
+		}),
+		deliver: (method: string, data: Record<string, unknown>) => handler?.({ method, data }),
+	};
+};
+
+const keyMessage = (toPeerId: string) => ({ toPeerId, keyId: 7, iv: new Uint8Array(12), data: new Uint8Array(48).buffer });
+
+const makeService = (enabled: boolean) => {
+	const peers = new Set<string>();
+	const nextStatus = new Map<string, 'new' | 'same' | 'changed'>();
+
+	return {
+		enabled,
+		peers,
+		nextStatus,
+		hasPeer: (id: string) => peers.has(id),
+		addPeer: vi.fn(async (id: string) => {
+			const status = nextStatus.get(id) ?? (peers.has(id) ? 'same' : 'new');
+
+			peers.add(id);
+
+			return status;
+		}),
+		removePeer: vi.fn((id: string) => { peers.delete(id); }),
+		getIdentityPublicKey: vi.fn(async () => new Uint8Array([ 4, 1, 2, 3 ])),
+		wrapLocalKeyFor: vi.fn(async (id: string) => keyMessage(id)),
+		wrapLocalKeyForAll: vi.fn(async () => [ ...peers ].map(keyMessage)),
+		rotateLocalKey: vi.fn(async () => undefined),
+		ratchetLocalKey: vi.fn(async () => undefined),
+		onRemoteKey: vi.fn(async () => undefined),
+		enable: vi.fn(async () => undefined),
+		onKeyNeeded: undefined as PeerCallback | undefined,
+		onEncryptionVerified: undefined as (() => void) | undefined,
+		onEncryptionUnverified: undefined as (() => void) | undefined,
+	};
+};
+
+const setup = ({ e2eeEnabled = true, serviceEnabled = true } = {}) => {
+	const signaling = makeSignaling();
+	const service = makeService(serviceEnabled);
+	const dispatch = vi.fn();
+	const next = vi.fn((action: unknown) => action);
+	const getState = () => ({
+		room: { e2eeEnabled },
+		me: { id: 'me' },
+		peers: { bob: { displayName: 'Bob' } },
+	});
+	const run = createE2eeMiddleware({ signalingService: signaling, e2eeService: service } as unknown as MiddlewareInput)(
+		{ dispatch, getState } as unknown as ApiInput
+	)(next);
+
+	run({ type: signalingActions.connect.type });
+
+	return { signaling, service, dispatch, run };
+};
+
+const keysSentTo = (signaling: ReturnType<typeof makeSignaling>): string[] =>
+	signaling.notify.mock.calls
+		.filter(([ method ]) => method === 'e2eeKey')
+		.map(([ , data ]) => (data as { toPeerId: string }).toPeerId);
+
+const identity = (peerId: string) => ({ peerId, identityPubKey: PUB });
+
+describe('E2EE middleware', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('does nothing in a room without end to end encryption', async () => {
+		const { signaling, service } = setup({ e2eeEnabled: false });
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(service.addPeer).not.toHaveBeenCalled();
+		expect(signaling.notify).not.toHaveBeenCalled();
+	});
+
+	it('answers a first contact with its identity and, after the batch window, an advanced key', async () => {
+		const { signaling, service } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(signaling.notify).toHaveBeenCalledWith('e2eeIdentity', expect.objectContaining({ toPeerId: 'bob' }));
+		expect(service.ratchetLocalKey).not.toHaveBeenCalled();
+		expect(keysSentTo(signaling)).toEqual([]);
+
+		await vi.advanceTimersByTimeAsync(200);
+
+		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
+	});
+
+	it('covers peers arriving together with a single advance', async () => {
+		const { signaling, service } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await signaling.deliver('e2eeIdentity', identity('carol'));
+		await signaling.deliver('e2eeIdentity', identity('dave'));
+		await vi.advanceTimersByTimeAsync(200);
+
+		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling).sort()).toEqual([ 'bob', 'carol', 'dave' ]);
+	});
+
+	it('treats a repeat announcement from a known peer as a key request and throttles it', async () => {
+		const { signaling, service } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await vi.advanceTimersByTimeAsync(200);
+		signaling.notify.mockClear();
+		service.ratchetLocalKey.mockClear();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
+		expect(service.ratchetLocalKey).not.toHaveBeenCalled();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
+
+		await vi.advanceTimersByTimeAsync(2000);
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(keysSentTo(signaling)).toEqual([ 'bob', 'bob' ]);
+	});
+
+	it('warns about a changed identity and does not hand it a key', async () => {
+		const { signaling, service, dispatch } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await vi.advanceTimersByTimeAsync(200);
+		signaling.notify.mockClear();
+		service.nextStatus.set('bob', 'changed');
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(dispatch).toHaveBeenCalledWith(e2eeActions.setPeerIdentityChanged({ peerId: 'bob' }));
+		expect(dispatch).toHaveBeenCalledWith(expect.objectContaining({ type: notificationsActions.enqueueNotification.type }));
+		expect(keysSentTo(signaling)).toEqual([]);
+	});
+
+	it('holds a key that arrives before the identity and applies it once the KEK exists', async () => {
+		const { signaling, service, dispatch } = setup();
+		const key = { fromPeerId: 'bob', keyId: 7, iv: toB64(new Uint8Array(12)), data: toB64(new Uint8Array(48)) };
+
+		await signaling.deliver('e2eeKey', key);
+
+		expect(service.onRemoteKey).not.toHaveBeenCalled();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(service.onRemoteKey).toHaveBeenCalledWith('bob', 7, expect.any(Uint8Array), expect.any(ArrayBuffer));
+		expect(dispatch).toHaveBeenCalledWith(e2eeActions.setPeerSecured({ peerId: 'bob' }));
+	});
+
+	it('applies a key from a known peer immediately', async () => {
+		const { signaling, service, dispatch } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await signaling.deliver('e2eeKey', { fromPeerId: 'bob', keyId: 7, iv: toB64(new Uint8Array(12)), data: toB64(new Uint8Array(48)) });
+
+		expect(service.onRemoteKey).toHaveBeenCalledTimes(1);
+		expect(dispatch).toHaveBeenCalledWith(e2eeActions.setPeerSecured({ peerId: 'bob' }));
+	});
+
+	it('replaces its key and redistributes it when a peer leaves', async () => {
+		const { signaling, service, dispatch, run } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await signaling.deliver('e2eeIdentity', identity('carol'));
+		await vi.advanceTimersByTimeAsync(200);
+		signaling.notify.mockClear();
+
+		run(peersActions.removePeer({ id: 'bob' }));
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(service.removePeer).toHaveBeenCalledWith('bob');
+		expect(dispatch).toHaveBeenCalledWith(e2eeActions.removePeer({ peerId: 'bob' }));
+		expect(service.rotateLocalKey).toHaveBeenCalledTimes(1);
+		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([ 'carol' ]);
+	});
+
+	it('asks a peer for its key by announcing to that peer alone', async () => {
+		const { signaling, service } = setup();
+
+		expect(service.onKeyNeeded).toBeDefined();
+		service.onKeyNeeded!('bob');
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(signaling.notify).toHaveBeenCalledWith('e2eeIdentity', expect.objectContaining({ toPeerId: 'bob' }));
+		expect(keysSentTo(signaling)).toEqual([]);
+	});
+
+	it('enables the service and announces to the whole room once joined', async () => {
+		const { signaling, service, run } = setup();
+
+		run(roomActions.setState('joined'));
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(service.enable).toHaveBeenCalledWith('me');
+
+		const [ method, data ] = signaling.notify.mock.calls[0];
+
+		expect(method).toBe('e2eeIdentity');
+		expect(data).not.toHaveProperty('toPeerId');
+	});
+
+	it('ignores a departure while the service is off', async () => {
+		const { service, run } = setup({ serviceEnabled: false });
+
+		run(peersActions.removePeer({ id: 'bob' }));
+		await vi.advanceTimersByTimeAsync(0);
+
+		expect(service.removePeer).not.toHaveBeenCalled();
+		expect(service.rotateLocalKey).not.toHaveBeenCalled();
+	});
+
+	it('sends nothing to a peer that left inside the batch window', async () => {
+		const { signaling, service, run } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		run(peersActions.removePeer({ id: 'bob' }));
+		await vi.advanceTimersByTimeAsync(200);
+
+		expect(service.rotateLocalKey).toHaveBeenCalledTimes(1);
+		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([]);
+	});
+
+	it('answers a broadcast from a peer reconnecting briefly with a key and nothing else', async () => {
+		const { signaling, service } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await signaling.deliver('e2eeIdentity', identity('carol'));
+		await vi.advanceTimersByTimeAsync(200);
+		signaling.notify.mockClear();
+		service.ratchetLocalKey.mockClear();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await vi.advanceTimersByTimeAsync(200);
+
+		const announcements = signaling.notify.mock.calls
+			.filter(([ method ]) => method === 'e2eeIdentity');
+
+		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
+		expect(service.ratchetLocalKey).not.toHaveBeenCalled();
+		expect(announcements).toHaveLength(0);
+	});
+
+	it('treats a peer returning after a long disconnect as a first contact', async () => {
+		const { signaling, service, run } = setup();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+		await vi.advanceTimersByTimeAsync(200);
+		run(peersActions.removePeer({ id: 'bob' }));
+		await vi.advanceTimersByTimeAsync(0);
+		signaling.notify.mockClear();
+		service.ratchetLocalKey.mockClear();
+
+		await signaling.deliver('e2eeIdentity', identity('bob'));
+
+		expect(signaling.notify).toHaveBeenCalledWith('e2eeIdentity', expect.objectContaining({ toPeerId: 'bob' }));
+
+		await vi.advanceTimersByTimeAsync(200);
+
+		expect(service.ratchetLocalKey).toHaveBeenCalledTimes(1);
+		expect(keysSentTo(signaling)).toEqual([ 'bob' ]);
+	});
+});

--- a/src/store/middlewares/e2eeMiddleware.tsx
+++ b/src/store/middlewares/e2eeMiddleware.tsx
@@ -17,7 +17,7 @@ const logger = new Logger('E2eeMiddleware');
 // identity; on first contact with a peer we derive a pairwise KEK and send our (wrapped) media key;
 // on leave we replace our key and redistribute it, on join we advance it and send it only to the
 // newcomer. The E2eeService owns the keys/workers; this just routes signals.
-const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptions): Middleware => {
+const createE2eeMiddleware = ({ signalingService, e2eeService, mediaService }: MiddlewareOptions): Middleware => {
 	logger.debug('createE2eeMiddleware()');
 
 	const announceIdentity = async (toPeerId?: string): Promise<void> => {
@@ -87,6 +87,41 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 		}, JOIN_BATCH_MS);
 	};
 
+	// A departure burns our key, because the leaver holds it. Replacing it costs a message per remaining
+	// peer, and every remaining peer does the same, so a room emptying pays that per person. Two things
+	// keep it in check. Departures are batched like arrivals, so people leaving together cost one
+	// replacement, at the price of the leaver being able to read up to the batch window. And a
+	// participant with no producer has nothing the leaver could read, so it only marks its key as
+	// burned and replaces it when it next starts sending, which in a lecture is most of the room.
+	const LEAVE_BATCH_MS = 200;
+	let departureTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const hasProducer = (): boolean =>
+		Object.values(mediaService.mediaSenders).some((sender) => Boolean(sender.producer));
+
+	const replaceAndDistribute = async (): Promise<void> => {
+		await e2eeService.rotateLocalKey();
+		await sendKeyToAll();
+	};
+
+	const scheduleDeparture = (): void => {
+		if (departureTimer) return;
+
+		departureTimer = setTimeout(() => {
+			departureTimer = undefined;
+
+			void (async () => {
+				if (!e2eeService.enabled) return;
+
+				try {
+					await replaceAndDistribute();
+				} catch (error) {
+					logger.error('replacing our key after a departure failed [error:%o]', error);
+				}
+			})();
+		}, LEAVE_BATCH_MS);
+	};
+
 	// Asking a peer for their key. There is no request message and none is needed: a peer that already
 	// knows us reads a repeat identity announcement as a request, since nothing else would prompt one.
 	// That keeps recovery on the two notifications the room server already relays.
@@ -118,6 +153,10 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 	const wireUnverifiedHandler = (dispatch: AppDispatch): void => {
 		if (unverifiedHandlerWired) return;
 		unverifiedHandlerWired = true;
+
+		// A key burned by a departure while we had nothing to send is replaced by the service the moment
+		// a producer starts; distributing the replacement is signalling, so it comes back through here.
+		e2eeService.onRotateRequired = replaceAndDistribute;
 
 		// The worker could not decrypt this peer for a sustained run of frames: their key never reached
 		// us, or we fell further behind their advances than we will derive. Announcing to them asks for
@@ -259,10 +298,8 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 				lastResend.delete(action.payload.id);
 
 				if (e2eeActive()) {
-					void (async () => {
-						await e2eeService.rotateLocalKey();
-						await sendKeyToAll();
-					})();
+					if (hasProducer()) scheduleDeparture();
+					else e2eeService.markKeyBurned();
 				}
 			}
 

--- a/src/store/middlewares/e2eeMiddleware.tsx
+++ b/src/store/middlewares/e2eeMiddleware.tsx
@@ -15,7 +15,8 @@ const logger = new Logger('E2eeMiddleware');
 
 // Zero-trust per-sender key exchange over the existing signaling relay. On join we announce our
 // identity; on first contact with a peer we derive a pairwise KEK and send our (wrapped) media key;
-// on leave we rotate + redistribute. The E2eeService owns the keys/workers; this just routes signals.
+// on leave we replace our key and redistribute it, on join we advance it and send it only to the
+// newcomer. The E2eeService owns the keys/workers; this just routes signals.
 const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptions): Middleware => {
 	logger.debug('createE2eeMiddleware()');
 
@@ -36,6 +37,74 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 		});
 	};
 
+	const sendKeyToAll = async (): Promise<void> => {
+		for (const msg of await e2eeService.wrapLocalKeyForAll()) {
+			signalingService.notify('e2eeKey', {
+				toPeerId: msg.toPeerId, keyId: msg.keyId, iv: toB64(msg.iv), data: toB64(msg.data),
+			});
+		}
+	};
+
+	// A peer arriving must not be able to read what was said before they came, so our key is advanced
+	// before they are sent it. Advancing is one way, so everyone already holding the key derives the
+	// next one themselves and only the newcomer needs a message.
+	//
+	// Arrivals are batched because joining a room produces one first contact per peer already there,
+	// and advancing once each would burn an epoch per peer and re-send to everyone met so far. One
+	// advance covers any number of peers that arrive together.
+	//
+	// A peer only learns that our key advanced by decrypting a frame under it, so anyone receiving no
+	// frames from us stays where it was: we are muted, or the SFU is not forwarding our video to them
+	// because they are not showing us. Those peers are recovered on demand rather than pre-emptively,
+	// by the request below, so advancing stays free no matter how large the room is.
+	const JOIN_BATCH_MS = 200;
+	const arriving = new Set<string>();
+	let arrivalTimer: ReturnType<typeof setTimeout> | undefined;
+
+	const scheduleArrival = (peerId: string): void => {
+		arriving.add(peerId);
+
+		if (arrivalTimer) return;
+
+		arrivalTimer = setTimeout(() => {
+			arrivalTimer = undefined;
+
+			const peers = [ ...arriving ];
+
+			arriving.clear();
+
+			void (async () => {
+				if (!e2eeService.enabled) return;
+
+				try {
+					await e2eeService.ratchetLocalKey();
+
+					for (const id of peers) await sendKeyTo(id);
+				} catch (error) {
+					logger.error('advancing our key for arriving peers failed [error:%o]', error);
+				}
+			})();
+		}, JOIN_BATCH_MS);
+	};
+
+	// Asking a peer for their key. There is no request message and none is needed: a peer that already
+	// knows us reads a repeat identity announcement as a request, since nothing else would prompt one.
+	// That keeps recovery on the two notifications the room server already relays.
+	//
+	// Answering is throttled so that a peer announcing repeatedly cannot turn into a flood of keys.
+	const RESEND_THROTTLE_MS = 2000;
+	const lastResend = new Map<string, number>();
+
+	const answerKeyRequest = async (peerId: string): Promise<void> => {
+		const now = Date.now();
+
+		if (now - (lastResend.get(peerId) ?? 0) < RESEND_THROTTLE_MS) return;
+
+		lastResend.set(peerId, now);
+
+		await sendKeyTo(peerId);
+	};
+
 	// An e2eeKey can arrive before we've finished deriving that sender's KEK (their addPeer/ECDH is
 	// still in flight — common cross-browser since Firefox's WebCrypto is slower). Buffer such keys by
 	// sender and apply them once the KEK lands, instead of dropping them with "no KEK for peer".
@@ -49,6 +118,15 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 	const wireUnverifiedHandler = (dispatch: AppDispatch): void => {
 		if (unverifiedHandlerWired) return;
 		unverifiedHandlerWired = true;
+
+		// The worker could not decrypt this peer for a sustained run of frames: their key never reached
+		// us, or we fell further behind their advances than we will derive. Announcing to them asks for
+		// a key, and is rate limited in the worker so this cannot become a loop.
+		e2eeService.onKeyNeeded = (peerId: string) => {
+			logger.debug('cannot decrypt a peer, asking for their key [peerId:%s]', peerId);
+
+			void announceIdentity(peerId);
+		};
 
 		e2eeService.onEncryptionVerified = () => {
 			logger.debug('E2EE verified — media is genuinely being encrypted');
@@ -117,7 +195,13 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 
 								if (firstContact) {
 									await announceIdentity(peerId);
-									await sendKeyTo(peerId);
+									scheduleArrival(peerId);
+								} else if (status !== 'changed') {
+									// Not a new peer, so this is them asking for our key. Refused when the
+									// identity just changed: identities are generated per join and peer ids are
+									// not reused, so a changed one for a peer we already know is not a peer
+									// reconnecting, and answering would hand our key to whoever supplied it.
+									await answerKeyRequest(peerId);
 								}
 
 								break;
@@ -160,21 +244,18 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 				})();
 			}
 
-			// Peer left: drop their KEK, then rotate our key + redistribute (forward secrecy).
+			// Peer left: drop their KEK, then replace our key and redistribute it. Advancing would not do
+			// here, because the peer who left can advance it exactly as easily as everyone still present.
 			if (peersActions.removePeer.match(action) && e2eeService.enabled) {
 				e2eeService.removePeer(action.payload.id);
 				dispatch(e2eeActions.removePeer({ peerId: action.payload.id }));
 				pendingKeys.delete(action.payload.id);
+				lastResend.delete(action.payload.id);
 
 				if (e2eeActive()) {
 					void (async () => {
 						await e2eeService.rotateLocalKey();
-
-						for (const msg of await e2eeService.wrapLocalKeyForAll()) {
-							signalingService.notify('e2eeKey', {
-								toPeerId: msg.toPeerId, keyId: msg.keyId, iv: toB64(msg.iv), data: toB64(msg.data),
-							});
-						}
+						await sendKeyToAll();
 					})();
 				}
 			}

--- a/src/store/middlewares/e2eeMiddleware.tsx
+++ b/src/store/middlewares/e2eeMiddleware.tsx
@@ -196,11 +196,17 @@ const createE2eeMiddleware = ({ signalingService, e2eeService }: MiddlewareOptio
 								if (firstContact) {
 									await announceIdentity(peerId);
 									scheduleArrival(peerId);
-								} else if (status !== 'changed') {
+								} else if (status !== 'changed' && !arriving.has(peerId)) {
 									// Not a new peer, so this is them asking for our key. Refused when the
 									// identity just changed: identities are generated per join and peer ids are
 									// not reused, so a changed one for a peer we already know is not a peer
 									// reconnecting, and answering would hand our key to whoever supplied it.
+									//
+									// Also refused while their arrival is still in the batch window. A newcomer
+									// answers our announcement with one of their own, which arrives here looking
+									// exactly like a request, and answering it would hand them the key from
+									// before the advance, which is the key the advance exists to keep from them.
+									// The batch sends them the advanced key moments later.
 									await answerKeyRequest(peerId);
 								}
 

--- a/src/utils/e2ee/E2eeKeyProvider.ts
+++ b/src/utils/e2ee/E2eeKeyProvider.ts
@@ -13,6 +13,7 @@ export interface RemoteKeyUpdate {
 	peerId: string;
 	keyId: number;
 	key: CryptoKey; // a remote sender's media key, for decrypting their frames
+	raw: Bytes; // the same key as bytes, so the worker can advance it without another message
 }
 
 export interface WrappedKeyMessage {
@@ -38,6 +39,7 @@ export interface E2eeKeyProvider {
 
 	localKey(): LocalKey | undefined;
 	rotateLocalKey(): Promise<LocalKey>;
+	ratchetLocalKey(): Promise<LocalKey>;
 
 	wrapLocalKeyFor(peerId: string): Promise<WrappedKeyMessage>;
 	wrapLocalKeyForAll(): Promise<WrappedKeyMessage[]>;

--- a/src/utils/e2ee/WebCryptoKeyProvider.test.ts
+++ b/src/utils/e2ee/WebCryptoKeyProvider.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from 'vitest';
+import { WebCryptoKeyProvider } from './WebCryptoKeyProvider';
+import { peerNamespace, ratchetRaw } from './crypto';
+
+const hex = (bytes: Uint8Array): string => Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+const provider = async (id: string): Promise<WebCryptoKeyProvider> => {
+	const p = new WebCryptoKeyProvider(id);
+
+	await p.init();
+
+	return p;
+};
+
+const introduce = async (a: WebCryptoKeyProvider, aId: string, b: WebCryptoKeyProvider, bId: string): Promise<void> => {
+	await a.addPeer(bId, await b.getIdentityPublicKey());
+	await b.addPeer(aId, await a.getIdentityPublicKey());
+};
+
+const receive = async (receiver: WebCryptoKeyProvider, fromId: string, sender: WebCryptoKeyProvider, toId: string) => {
+	const msg = await sender.wrapLocalKeyFor(toId);
+
+	return receiver.unwrapRemoteKey(fromId, msg.keyId, msg.iv, msg.data);
+};
+
+describe('local key', () => {
+	it('starts at epoch zero in its own namespace', async () => {
+		const alice = await provider('alice');
+		const local = alice.localKey();
+
+		expect(local).toBeDefined();
+		expect(local!.keyId >>> 8).toBe(await peerNamespace('alice'));
+		expect(local!.keyId & 0xff).toBe(0);
+	});
+
+	it('refuses to advance before it has a key', async () => {
+		await expect(new WebCryptoKeyProvider('alice').ratchetLocalKey()).rejects.toThrow(/no local media key/);
+	});
+});
+
+describe('peers and identity pinning', () => {
+	it('pins the first identity and reports later ones', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+		const impostor = await provider('bob');
+
+		expect(await alice.addPeer('bob', await bob.getIdentityPublicKey())).toBe('new');
+		expect(await alice.addPeer('bob', await bob.getIdentityPublicKey())).toBe('same');
+		expect(await alice.addPeer('bob', await impostor.getIdentityPublicKey())).toBe('changed');
+	});
+
+	it('does not add itself', async () => {
+		const alice = await provider('alice');
+
+		expect(await alice.addPeer('alice', await alice.getIdentityPublicKey())).toBe('same');
+		expect(alice.hasPeer('alice')).toBe(false);
+	});
+
+	it('forgets a removed peer', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+
+		await introduce(alice, 'alice', bob, 'bob');
+		expect(alice.hasPeer('bob')).toBe(true);
+
+		alice.removePeer('bob');
+		expect(alice.hasPeer('bob')).toBe(false);
+		await expect(alice.wrapLocalKeyFor('bob')).rejects.toThrow(/no KEK/);
+	});
+});
+
+describe('key distribution', () => {
+	it('delivers the same media key to every peer', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+		const carol = await provider('carol');
+
+		await introduce(alice, 'alice', bob, 'bob');
+		await introduce(alice, 'alice', carol, 'carol');
+
+		const atBob = await receive(bob, 'alice', alice, 'bob');
+		const atCarol = await receive(carol, 'alice', alice, 'carol');
+
+		expect(atBob.keyId).toBe(alice.localKey()!.keyId);
+		expect(atBob.raw.length).toBe(32);
+		expect(hex(atBob.raw)).toBe(hex(atCarol.raw));
+		expect((await alice.wrapLocalKeyForAll()).map((m) => m.toPeerId).sort()).toEqual([ 'bob', 'carol' ]);
+	});
+
+	it('rejects a key whose namespace does not match the stamped sender', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+		const carol = await provider('carol');
+
+		await introduce(alice, 'alice', bob, 'bob');
+		await introduce(bob, 'bob', carol, 'carol');
+
+		const msg = await alice.wrapLocalKeyFor('bob');
+
+		await expect(bob.unwrapRemoteKey('carol', msg.keyId, msg.iv, msg.data)).rejects.toThrow(/namespace mismatch/);
+	});
+
+	it('rejects a key from a peer it has not met', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+
+		await alice.addPeer('bob', await bob.getIdentityPublicKey());
+
+		const msg = await alice.wrapLocalKeyFor('bob');
+
+		await expect(bob.unwrapRemoteKey('alice', msg.keyId, msg.iv, msg.data)).rejects.toThrow(/no KEK/);
+	});
+
+	it('re-keys the pair when a peer presents a changed identity', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+		const impostor = await provider('bob');
+
+		await introduce(alice, 'alice', bob, 'bob');
+		await impostor.addPeer('alice', await alice.getIdentityPublicKey());
+		await alice.addPeer('bob', await impostor.getIdentityPublicKey());
+
+		const msg = await alice.wrapLocalKeyFor('bob');
+
+		await expect(impostor.unwrapRemoteKey('alice', msg.keyId, msg.iv, msg.data)).resolves.toBeDefined();
+		await expect(bob.unwrapRemoteKey('alice', msg.keyId, msg.iv, msg.data)).rejects.toThrow();
+	});
+});
+
+describe('changing the local key', () => {
+	it('replaces it with unrelated material on rotate', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+
+		await introduce(alice, 'alice', bob, 'bob');
+
+		const before = await receive(bob, 'alice', alice, 'bob');
+
+		await alice.rotateLocalKey();
+
+		const after = await receive(bob, 'alice', alice, 'bob');
+
+		expect(after.keyId & 0xff).toBe(1);
+		expect(hex(after.raw)).not.toBe(hex(before.raw));
+		expect(hex(after.raw)).not.toBe(hex(await ratchetRaw(before.raw)));
+	});
+
+	it('advances it on ratchet so a holder of the previous key can derive it', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+
+		await introduce(alice, 'alice', bob, 'bob');
+
+		const before = await receive(bob, 'alice', alice, 'bob');
+
+		await alice.ratchetLocalKey();
+
+		const after = await receive(bob, 'alice', alice, 'bob');
+
+		expect(after.keyId & 0xff).toBe(1);
+		expect(hex(after.raw)).toBe(hex(await ratchetRaw(before.raw)));
+	});
+
+	it('serializes concurrent changes so no two keys share an epoch', async () => {
+		const alice = await provider('alice');
+		const [ replaced, advanced, replacedAgain ] = await Promise.all([
+			alice.rotateLocalKey(),
+			alice.ratchetLocalKey(),
+			alice.rotateLocalKey(),
+		]);
+
+		expect(replaced.keyId & 0xff).toBe(1);
+		expect(advanced.keyId & 0xff).toBe(2);
+		expect(replacedAgain.keyId & 0xff).toBe(3);
+		expect(alice.localKey()!.keyId).toBe(replacedAgain.keyId);
+	});
+
+	it('derives a concurrent advance from the replacement that preceded it', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+
+		await introduce(alice, 'alice', bob, 'bob');
+
+		const [ , advanced ] = await Promise.all([ alice.rotateLocalKey(), alice.ratchetLocalKey() ]);
+		const current = await receive(bob, 'alice', alice, 'bob');
+
+		expect(current.keyId).toBe(advanced.keyId);
+		expect(current.keyId & 0xff).toBe(2);
+	});
+
+	it('wraps the epoch after 256 changes', async () => {
+		const alice = await provider('alice');
+
+		for (let i = 0; i < 256; i++) await alice.rotateLocalKey();
+
+		expect(alice.localKey()!.keyId & 0xff).toBe(0);
+	});
+
+	it('recovers the change queue after a change that fails', async () => {
+		const alice = new WebCryptoKeyProvider('alice');
+
+		await expect(alice.ratchetLocalKey()).rejects.toThrow(/no local media key/);
+		await alice.init();
+
+		expect((await alice.rotateLocalKey()).keyId & 0xff).toBe(1);
+	});
+
+	it('never wraps new bytes under the previous id while a change is in flight', async () => {
+		const alice = await provider('alice');
+		const bob = await provider('bob');
+
+		await introduce(alice, 'alice', bob, 'bob');
+
+		const before = await receive(bob, 'alice', alice, 'bob');
+		const change = alice.rotateLocalKey();
+		const during = await alice.wrapLocalKeyFor('bob');
+
+		await change;
+
+		const seen = await bob.unwrapRemoteKey('alice', during.keyId, during.iv, during.data);
+		const after = await receive(bob, 'alice', alice, 'bob');
+		const matchesBefore = seen.keyId === before.keyId && hex(seen.raw) === hex(before.raw);
+		const matchesAfter = seen.keyId === after.keyId && hex(seen.raw) === hex(after.raw);
+
+		expect(matchesBefore || matchesAfter).toBe(true);
+	});
+});

--- a/src/utils/e2ee/WebCryptoKeyProvider.ts
+++ b/src/utils/e2ee/WebCryptoKeyProvider.ts
@@ -1,5 +1,5 @@
 import { E2eeKeyProvider, IdentityStatus, LocalKey, RemoteKeyUpdate, WrappedKeyMessage } from './E2eeKeyProvider';
-import { Bytes, deriveKek, Identity, importMediaKey, makeIdentity, peerNamespace, randomKeyRaw, toB64, unwrapKey, wrapKey } from './crypto';
+import { Bytes, deriveKek, Identity, importMediaKey, makeIdentity, peerNamespace, randomKeyRaw, ratchetRaw, toB64, unwrapKey, wrapKey } from './crypto';
 
 // Zero-server-trust, WASM-free key provider:
 //  - one ephemeral ECDH identity per session (TOFU pinned by peers)
@@ -14,6 +14,11 @@ export class WebCryptoKeyProvider implements E2eeKeyProvider {
 	readonly #pinnedIdentities = new Map<string, string>(); // peerId -> TOFU-pinned identity pubkey (b64)
 	#localRaw?: Bytes;
 	#local?: LocalKey;
+	// Key changes run one at a time. A departure's replacement and an arrival's advance can be in
+	// flight together, and each bumps the epoch before it awaits, so left to interleave they would
+	// produce two different keys carrying the same epoch: receivers and our own encoder could then
+	// hold different keys under one identifier, with nothing to say which is right.
+	#keyChange: Promise<unknown> = Promise.resolve();
 
 	constructor(myPeerId: string) {
 		this.#myPeerId = myPeerId;
@@ -62,10 +67,32 @@ export class WebCryptoKeyProvider implements E2eeKeyProvider {
 		return this.#local;
 	}
 
-	async rotateLocalKey(): Promise<LocalKey> {
-		this.#epoch = (this.#epoch + 1) & 0xff;
+	// Replaces the key outright. Used when someone leaves: they hold the old key, so the new one has
+	// to be unrelated to it and has to be delivered to everyone still here.
+	rotateLocalKey(): Promise<LocalKey> {
+		return this.#serialized(() => {
+			this.#epoch = (this.#epoch + 1) & 0xff;
 
-		return this.#freshLocalKey();
+			return this.#freshLocalKey();
+		});
+	}
+
+	// Advances the key instead of replacing it. Used when someone joins: everyone already holding the
+	// old key derives this one themselves, so only the newcomer is sent anything, and the newcomer
+	// cannot run it backwards to read what came before.
+	ratchetLocalKey(): Promise<LocalKey> {
+		return this.#serialized(async () => {
+			if (!this.#localRaw) throw new Error('no local media key');
+
+			// Derive before the epoch moves. The epoch tells receivers how many times to advance, so a
+			// failed derivation that had already bumped it would put the two permanently out of step:
+			// we would label a key one step along as though it were two, and nobody could derive it.
+			const raw = await ratchetRaw(this.#localRaw);
+
+			this.#epoch = (this.#epoch + 1) & 0xff;
+
+			return this.#setLocalKey(raw);
+		});
 	}
 
 	async wrapLocalKeyFor(peerId: string): Promise<WrappedKeyMessage> {
@@ -74,9 +101,14 @@ export class WebCryptoKeyProvider implements E2eeKeyProvider {
 		if (!kek) throw new Error(`no KEK for peer ${peerId}`);
 		if (!this.#localRaw || !this.#local) throw new Error('no local media key');
 
-		const { iv, data } = await wrapKey(kek, this.#localRaw);
+		// Both halves are read before the await. A key change completing during the wrap would
+		// otherwise pair the previous bytes with the new identifier, and the recipient would file a
+		// key under an id it decrypts nothing for.
+		const raw = this.#localRaw;
+		const { keyId } = this.#local;
+		const { iv, data } = await wrapKey(kek, raw);
 
-		return { toPeerId: peerId, keyId: this.#local.keyId, iv, data };
+		return { toPeerId: peerId, keyId, iv, data };
 	}
 
 	async wrapLocalKeyForAll(): Promise<WrappedKeyMessage[]> {
@@ -99,18 +131,31 @@ export class WebCryptoKeyProvider implements E2eeKeyProvider {
 		if ((keyId >>> 8) !== await peerNamespace(fromPeerId))
 			throw new Error(`keyId namespace mismatch for peer ${fromPeerId}`);
 
-		const key = await importMediaKey(await unwrapKey(kek, iv, data));
+		const raw = await unwrapKey(kek, iv, data);
 
-		return { peerId: fromPeerId, keyId, key };
+		return { peerId: fromPeerId, keyId, key: await importMediaKey(raw), raw };
 	}
 
-	async #freshLocalKey(): Promise<LocalKey> {
-		this.#localRaw = randomKeyRaw();
-		this.#local = {
-			keyId: ((this.#namespace << 8) | (this.#epoch & 0xff)) >>> 0,
-			key: await importMediaKey(this.#localRaw),
-		};
+	#freshLocalKey(): Promise<LocalKey> {
+		return this.#setLocalKey(randomKeyRaw());
+	}
+
+	// The bytes and the key are assigned together, after the import. A wrap that ran between the two
+	// would otherwise send the new bytes under the old identifier.
+	async #setLocalKey(raw: Bytes): Promise<LocalKey> {
+		const key = await importMediaKey(raw);
+
+		this.#localRaw = raw;
+		this.#local = { keyId: ((this.#namespace << 8) | (this.#epoch & 0xff)) >>> 0, key };
 
 		return this.#local;
+	}
+
+	#serialized<T>(change: () => Promise<T>): Promise<T> {
+		const run = this.#keyChange.then(change, change);
+
+		this.#keyChange = run.catch(() => undefined);
+
+		return run;
 	}
 }

--- a/src/utils/e2ee/codecChoice.test.ts
+++ b/src/utils/e2ee/codecChoice.test.ts
@@ -71,6 +71,15 @@ describe('chooseSendCodec with encryption', () => {
 		expect(chooseSendCodec([ pcmu, opus ], { e2ee: true, kind: 'audio' })).toBeUndefined();
 	});
 
+	it('never picks an audio codec for a video track from a real, mixed capabilities list', () => {
+		const rtx = { mimeType: 'video/rtx', clockRate: 90000 };
+		const routerOrdered = [ opus, vp8, rtx, vp9, rtx, h264, rtx ];
+
+		expect(chooseSendCodec(routerOrdered, { e2ee: true, kind: 'video' })).toBe(vp8);
+		expect(chooseSendCodec([ opus, h264, vp9 ], { e2ee: true, kind: 'video' })).toBe(vp9);
+		expect(chooseSendCodec([ opus, h264, av1 ], { e2ee: true, kind: 'video' })).toBeUndefined();
+	});
+
 	it('returns the offered object itself, so negotiation parameters travel with it', () => {
 		const chosen = chooseSendCodec([ h264, vp8 ], { e2ee: true, kind: 'video' });
 

--- a/src/utils/e2ee/codecChoice.test.ts
+++ b/src/utils/e2ee/codecChoice.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { chooseSendCodec, isProtectableCodec } from './codecChoice';
+
+const h264 = { mimeType: 'video/H264', clockRate: 90000 };
+const vp8 = { mimeType: 'video/VP8', clockRate: 90000 };
+const vp9 = { mimeType: 'video/VP9', clockRate: 90000 };
+const av1 = { mimeType: 'video/AV1', clockRate: 90000 };
+const opus = { mimeType: 'audio/opus', clockRate: 48000 };
+const pcmu = { mimeType: 'audio/PCMU', clockRate: 8000 };
+
+describe('isProtectableCodec', () => {
+	it('accepts Opus, VP8 and VP9 in any case', () => {
+		expect(isProtectableCodec('audio/opus')).toBe(true);
+		expect(isProtectableCodec('video/VP8')).toBe(true);
+		expect(isProtectableCodec('video/vp9')).toBe(true);
+		expect(isProtectableCodec('VIDEO/VP8')).toBe(true);
+	});
+
+	it('refuses everything the worker has no clear byte layout for', () => {
+		expect(isProtectableCodec('video/H264')).toBe(false);
+		expect(isProtectableCodec('video/AV1')).toBe(false);
+		expect(isProtectableCodec('audio/PCMU')).toBe(false);
+		expect(isProtectableCodec(undefined)).toBe(false);
+		expect(isProtectableCodec('')).toBe(false);
+	});
+
+	it('matches the whole mime type, not a prefix or suffix', () => {
+		expect(isProtectableCodec('video/vp8x')).toBe(false);
+		expect(isProtectableCodec('xvideo/vp8')).toBe(false);
+	});
+});
+
+describe('chooseSendCodec without encryption', () => {
+	it('returns the codec that was asked for, by lower case mime type', () => {
+		expect(chooseSendCodec([ h264, vp8, vp9 ], { e2ee: false, kind: 'video', requested: 'video/vp9' })).toBe(vp9);
+		expect(chooseSendCodec([ opus, pcmu ], { e2ee: false, kind: 'audio', requested: 'audio/opus' })).toBe(opus);
+	});
+
+	it('returns nothing when nothing was asked for, leaving negotiation to decide', () => {
+		expect(chooseSendCodec([ h264, vp8, vp9 ], { e2ee: false, kind: 'video' })).toBeUndefined();
+	});
+
+	it('returns nothing when the requested codec is not offered', () => {
+		expect(chooseSendCodec([ h264, vp8 ], { e2ee: false, kind: 'video', requested: 'video/vp9' })).toBeUndefined();
+	});
+
+	it('copes with no capabilities at all', () => {
+		expect(chooseSendCodec(undefined, { e2ee: false, kind: 'video', requested: 'video/vp8' })).toBeUndefined();
+	});
+});
+
+describe('chooseSendCodec with encryption', () => {
+	it('prefers the first protectable video codec even when H264 is offered first', () => {
+		expect(chooseSendCodec([ h264, vp8, vp9 ], { e2ee: true, kind: 'video' })).toBe(vp8);
+		expect(chooseSendCodec([ h264, vp9, vp8 ], { e2ee: true, kind: 'video' })).toBe(vp9);
+	});
+
+	it('overrides a request for a codec it cannot protect', () => {
+		expect(chooseSendCodec([ h264, vp8 ], { e2ee: true, kind: 'video', requested: 'video/h264' })).toBe(vp8);
+	});
+
+	it('returns nothing when no video codec can be protected, so negotiation is refused afterwards', () => {
+		const chosen = chooseSendCodec([ h264, av1 ], { e2ee: true, kind: 'video' });
+
+		expect(chosen).toBeUndefined();
+		expect(isProtectableCodec(h264.mimeType)).toBe(false);
+	});
+
+	it('leaves audio to the requested codec, as without encryption', () => {
+		expect(chooseSendCodec([ pcmu, opus ], { e2ee: true, kind: 'audio', requested: 'audio/opus' })).toBe(opus);
+		expect(chooseSendCodec([ pcmu, opus ], { e2ee: true, kind: 'audio' })).toBeUndefined();
+	});
+
+	it('returns the offered object itself, so negotiation parameters travel with it', () => {
+		const chosen = chooseSendCodec([ h264, vp8 ], { e2ee: true, kind: 'video' });
+
+		expect(chosen).toBe(vp8);
+		expect(chosen?.clockRate).toBe(90000);
+	});
+});

--- a/src/utils/e2ee/codecChoice.ts
+++ b/src/utils/e2ee/codecChoice.ts
@@ -17,8 +17,13 @@ export type SendCodecChoice = {
 // With E2EE on, choose a codec the worker can protect instead of leaving it to negotiation, which is
 // free to settle on H264. Without E2EE this keeps the previous behaviour exactly: the codec that was
 // asked for, or nothing, in which case negotiation decides.
+// The capabilities list mixes audio and video in router order, with Opus first, and Opus is
+// protectable. Filtering on protectability alone hands a video producer an audio codec, which
+// mediasoup rejects with "no matching codec found" before any transform is attached.
+const isVideo = (mimeType: string): boolean => mimeType.toLowerCase().startsWith('video/');
+
 export const chooseSendCodec = <T extends CodecLike>(codecs: T[] | undefined, choice: SendCodecChoice): T | undefined => {
-	if (choice.e2ee && choice.kind === 'video') return codecs?.find((c) => E2EE_PROTECTABLE_CODEC.test(c.mimeType));
+	if (choice.e2ee && choice.kind === 'video') return codecs?.find((c) => isVideo(c.mimeType) && E2EE_PROTECTABLE_CODEC.test(c.mimeType));
 
 	return codecs?.find((c) => c.mimeType.toLowerCase() === choice.requested);
 };

--- a/src/utils/e2ee/codecChoice.ts
+++ b/src/utils/e2ee/codecChoice.ts
@@ -1,0 +1,24 @@
+// Codecs the E2EE worker can split correctly. Opus and VP8/VP9 have a fixed or cheaply derived clear
+// header, so the SFU keeps what it needs for forwarding and the rest is encrypted. H264 does not: the
+// browser packetizes NAL units AFTER our transform has run, so encrypting past a fixed offset leaves
+// the packetizer walking ciphertext and the stream is broken rather than protected.
+export const E2EE_PROTECTABLE_CODEC = /^(audio\/opus|video\/vp8|video\/vp9)$/i;
+
+export const isProtectableCodec = (mimeType?: string): boolean => E2EE_PROTECTABLE_CODEC.test(mimeType ?? '');
+
+type CodecLike = { mimeType: string };
+
+export type SendCodecChoice = {
+	e2ee: boolean;
+	kind?: string;
+	requested?: string;
+};
+
+// With E2EE on, choose a codec the worker can protect instead of leaving it to negotiation, which is
+// free to settle on H264. Without E2EE this keeps the previous behaviour exactly: the codec that was
+// asked for, or nothing, in which case negotiation decides.
+export const chooseSendCodec = <T extends CodecLike>(codecs: T[] | undefined, choice: SendCodecChoice): T | undefined => {
+	if (choice.e2ee && choice.kind === 'video') return codecs?.find((c) => E2EE_PROTECTABLE_CODEC.test(c.mimeType));
+
+	return codecs?.find((c) => c.mimeType.toLowerCase() === choice.requested);
+};

--- a/src/utils/e2ee/crypto.test.ts
+++ b/src/utils/e2ee/crypto.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import {
+	deriveKek,
+	fromB64,
+	importMediaKey,
+	makeIdentity,
+	peerNamespace,
+	randomKeyRaw,
+	ratchetRaw,
+	toB64,
+	unwrapKey,
+	wrapKey,
+} from './crypto';
+
+const hex = (bytes: Uint8Array): string => Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+describe('ratchetRaw', () => {
+	it('is deterministic for the same input', async () => {
+		const raw = randomKeyRaw();
+
+		expect(hex(await ratchetRaw(raw))).toBe(hex(await ratchetRaw(raw)));
+	});
+
+	it('produces a 32 byte key that differs at every step', async () => {
+		let raw = randomKeyRaw();
+		const seen = new Set([ hex(raw) ]);
+
+		for (let i = 0; i < 8; i++) {
+			raw = await ratchetRaw(raw);
+			expect(raw.length).toBe(32);
+			seen.add(hex(raw));
+		}
+
+		expect(seen.size).toBe(9);
+	});
+});
+
+describe('identity and pairwise KEK', () => {
+	it('keeps the private key non-extractable and exports an uncompressed public point', async () => {
+		const id = await makeIdentity();
+
+		expect(id.priv.extractable).toBe(false);
+		expect(id.pubRaw.length).toBe(65);
+		expect(id.pubRaw[0]).toBe(4);
+	});
+
+	it('derives the same KEK on both sides of the exchange', async () => {
+		const alice = await makeIdentity();
+		const bob = await makeIdentity();
+		const kekAb = await deriveKek(alice.priv, bob.pubRaw);
+		const kekBa = await deriveKek(bob.priv, alice.pubRaw);
+		const raw = randomKeyRaw();
+		const { iv, data } = await wrapKey(kekAb, raw);
+
+		expect(hex(await unwrapKey(kekBa, iv, data))).toBe(hex(raw));
+	});
+
+	it('does not let a third party unwrap', async () => {
+		const alice = await makeIdentity();
+		const bob = await makeIdentity();
+		const carol = await makeIdentity();
+		const kekAb = await deriveKek(alice.priv, bob.pubRaw);
+		const kekAc = await deriveKek(alice.priv, carol.pubRaw);
+		const { iv, data } = await wrapKey(kekAb, randomKeyRaw());
+
+		await expect(unwrapKey(kekAc, iv, data)).rejects.toThrow();
+	});
+});
+
+describe('wrapKey and unwrapKey', () => {
+	it('rejects a tampered ciphertext', async () => {
+		const id = await makeIdentity();
+		const other = await makeIdentity();
+		const kek = await deriveKek(id.priv, other.pubRaw);
+		const { iv, data } = await wrapKey(kek, randomKeyRaw());
+		const tampered = new Uint8Array(data);
+
+		tampered[5] ^= 0x01;
+		await expect(unwrapKey(kek, iv, tampered.buffer)).rejects.toThrow();
+	});
+
+	it('rejects a tampered iv', async () => {
+		const id = await makeIdentity();
+		const other = await makeIdentity();
+		const kek = await deriveKek(id.priv, other.pubRaw);
+		const { iv, data } = await wrapKey(kek, randomKeyRaw());
+		const tampered = new Uint8Array(iv);
+
+		tampered[0] ^= 0x01;
+		await expect(unwrapKey(kek, tampered, data)).rejects.toThrow();
+	});
+
+	it('uses a fresh iv for every wrap', async () => {
+		const id = await makeIdentity();
+		const other = await makeIdentity();
+		const kek = await deriveKek(id.priv, other.pubRaw);
+		const raw = randomKeyRaw();
+		const first = await wrapKey(kek, raw);
+		const second = await wrapKey(kek, raw);
+
+		expect(hex(first.iv)).not.toBe(hex(second.iv));
+		expect(hex(new Uint8Array(first.data))).not.toBe(hex(new Uint8Array(second.data)));
+	});
+});
+
+describe('peerNamespace', () => {
+	it('fits in 24 bits and is stable for a peer id', async () => {
+		const ns = await peerNamespace('peer-1');
+
+		expect(ns).toBeGreaterThanOrEqual(0);
+		expect(ns).toBeLessThan(1 << 24);
+		expect(await peerNamespace('peer-1')).toBe(ns);
+	});
+
+	it('differs between peers', async () => {
+		expect(await peerNamespace('peer-1')).not.toBe(await peerNamespace('peer-2'));
+	});
+});
+
+describe('base64', () => {
+	it('round trips every byte value', () => {
+		const bytes = new Uint8Array(256).map((_, i) => i);
+
+		expect(hex(fromB64(toB64(bytes)))).toBe(hex(bytes));
+	});
+
+	it('round trips an empty buffer', () => {
+		expect(fromB64(toB64(new Uint8Array(0))).length).toBe(0);
+	});
+});
+
+describe('importMediaKey', () => {
+	it('yields a non-extractable AES-GCM key for both directions', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+
+		expect(key.extractable).toBe(false);
+		expect(key.algorithm.name).toBe('AES-GCM');
+		expect(key.usages).toEqual(expect.arrayContaining([ 'encrypt', 'decrypt' ]));
+	});
+});

--- a/src/utils/e2ee/crypto.ts
+++ b/src/utils/e2ee/crypto.ts
@@ -51,6 +51,18 @@ export const unwrapKey = async (kek: CryptoKey, iv: Bytes, data: ArrayBuffer): P
 
 export const randomKeyRaw = (): Bytes => globalThis.crypto.getRandomValues(new Uint8Array(32));
 
+// Advance a media key one step. The next key is derived from the current one and the current one
+// cannot be recovered from it, so everyone already holding a key can move to the next without a
+// message while a newcomer given only the advanced key cannot read anything sent under the old one.
+export const ratchetRaw = async (raw: Bytes): Promise<Bytes> => {
+	const hk = await subtle.importKey('raw', raw, 'HKDF', false, [ 'deriveBits' ]);
+
+	return new Uint8Array(await subtle.deriveBits(
+		{ name: 'HKDF', hash: 'SHA-256', salt: te.encode('edumeet-e2ee/v1'), info: te.encode('ratchet') },
+		hk, 256
+	));
+};
+
 // The per-participant media key, ready for the SFrame worker (non-extractable).
 export const importMediaKey = (raw: Bytes): Promise<CryptoKey> =>
 	subtle.importKey('raw', raw, 'AES-GCM', false, [ 'encrypt', 'decrypt' ]);

--- a/src/utils/e2ee/frameCrypto.test.ts
+++ b/src/utils/e2ee/frameCrypto.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import { Bytes, importMediaKey, randomKeyRaw, ratchetRaw } from './crypto';
+import { clearBytes, GCM_TAG_BYTES, NONCE_BYTES, nonceFor, open, parseFrame, seal, sealFrame, Sealed } from './frameCrypto';
+
+const KEY_ID = ((0xabcdef << 8) | 5) >>> 0;
+
+const hex = (bytes: Uint8Array): string => Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+
+const frame = (length: number, firstByte: number): Bytes => {
+	const out = globalThis.crypto.getRandomValues(new Uint8Array(length));
+
+	if (length > 0) out[0] = firstByte;
+
+	return out;
+};
+
+const sealedBytes = async (data: Bytes, codec: string, key: CryptoKey, counter = 0): Promise<Bytes> => {
+	const result = await sealFrame(data, codec, key, KEY_ID, counter);
+
+	if (result.kind !== 'sealed') throw new Error(`expected a sealed frame, got ${result.kind}`);
+
+	return result.data;
+};
+
+const parsedSealed = (data: Bytes, codec: string): Sealed => {
+	const shape = parseFrame(data, codec);
+
+	if (shape.kind !== 'sealed') throw new Error(`expected a sealed frame, got ${shape.kind}`);
+
+	return shape;
+};
+
+const codecs: Array<[ string, Bytes ]> = [
+	[ 'opus', frame(40, 0x78) ],
+	[ 'vp8', frame(200, 0x10) ],
+	[ 'vp8', frame(200, 0x11) ],
+	[ 'vp9', frame(120, 0x82) ],
+];
+
+describe('clear header', () => {
+	it('leaves exactly the bytes the SFU needs', () => {
+		expect(clearBytes(frame(10, 0x78), 'opus')).toBe(1);
+		expect(clearBytes(frame(10, 0x82), 'vp9')).toBe(0);
+		expect(clearBytes(frame(10, 0x10), 'vp8')).toBe(10);
+		expect(clearBytes(frame(10, 0x11), 'vp8')).toBe(3);
+		expect(clearBytes(frame(10, 0x65), 'h264')).toBe(3);
+	});
+});
+
+describe('nonce', () => {
+	it('is the key id followed by the counter, big endian', () => {
+		const nonce = nonceFor(0xffffffff, (2 ** 40) + 7);
+		const dv = new DataView(nonce.buffer);
+
+		expect(nonce.length).toBe(NONCE_BYTES);
+		expect(dv.getUint32(0)).toBe(0xffffffff);
+		expect(dv.getBigUint64(4)).toBe(BigInt((2 ** 40) + 7));
+	});
+
+	it('differs per counter and repeats for a repeated counter', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+		const data = frame(40, 0x78);
+		const nonces = await Promise.all([ 0, 1, 2, 0 ].map(async (counter) =>
+			hex((await sealedBytes(data, 'opus', key, counter)).subarray(1, 1 + NONCE_BYTES))));
+
+		expect(new Set(nonces.slice(0, 3)).size).toBe(3);
+		expect(nonces[3]).toBe(nonces[0]);
+	});
+});
+
+describe('seal and open', () => {
+	it.each(codecs)('round trips a %s frame', async (codec, data) => {
+		const key = await importMediaKey(randomKeyRaw());
+		const header = clearBytes(data, codec);
+		const wire = await sealedBytes(data, codec, key);
+
+		expect(wire.length).toBe(data.length + NONCE_BYTES + GCM_TAG_BYTES);
+		expect(hex(wire.subarray(0, header))).toBe(hex(data.subarray(0, header)));
+
+		const shape = parsedSealed(wire, codec);
+
+		expect(shape.header).toBe(header);
+		expect(shape.keyId).toBe(KEY_ID);
+		expect(hex(await open(shape, key))).toBe(hex(data));
+	});
+
+	it('hides everything past the clear header', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+		const data = frame(200, 0x10);
+		const wire = await sealedBytes(data, 'vp8', key);
+
+		expect(hex(wire.subarray(10 + NONCE_BYTES))).not.toContain(hex(data.subarray(10, 26)));
+	});
+
+	it('carries the sender namespace in the key id', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+		const wire = await sealedBytes(frame(40, 0x78), 'opus', key);
+
+		expect(parsedSealed(wire, 'opus').keyId >>> 8).toBe(0xabcdef);
+	});
+});
+
+describe('frames with nothing to protect', () => {
+	it('pass through untouched on both sides', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+
+		for (const [ codec, data ] of [ [ 'opus', frame(1, 0x78) ], [ 'opus', frame(0, 0) ], [ 'vp8', frame(10, 0x10) ], [ 'vp8', frame(3, 0x11) ], [ 'vp9', frame(0, 0) ] ] as Array<[ string, Bytes ]>) {
+			expect((await sealFrame(data, codec, key, KEY_ID, 0)).kind).toBe('passthrough');
+			expect(parseFrame(data, codec).kind).toBe('passthrough');
+		}
+	});
+});
+
+describe('frames no sender could have produced', () => {
+	it.each([ [ 'opus', 0x78 ], [ 'vp8', 0x11 ], [ 'vp8', 0x10 ] ])('are refused for %s between passthrough and the smallest ciphertext', (codec, firstByte) => {
+		const header = clearBytes(frame(1, firstByte), codec);
+		const smallest = header + NONCE_BYTES + GCM_TAG_BYTES + 1;
+
+		for (let length = header + 1; length < smallest; length++)
+			expect(parseFrame(frame(length, firstByte), codec).kind).toBe('impossible');
+
+		expect(parseFrame(frame(smallest, firstByte), codec).kind).toBe('sealed');
+	});
+});
+
+describe('tampering', () => {
+	const tamperedAt = async (codec: string, data: Bytes, offset: number) => {
+		const key = await importMediaKey(randomKeyRaw());
+		const wire = await sealedBytes(data, codec, key);
+		const index = offset < 0 ? wire.length + offset : offset;
+
+		wire[index] ^= 0x01;
+
+		return { shape: parseFrame(wire, codec), key };
+	};
+
+	it('rejects a changed clear byte, which the SFU can read but must not alter', async () => {
+		const { shape, key } = await tamperedAt('vp8', frame(200, 0x10), 5);
+
+		expect(shape.kind).toBe('sealed');
+		await expect(open(shape as Sealed, key)).rejects.toThrow();
+	});
+
+	it('rejects a changed nonce', async () => {
+		const { shape, key } = await tamperedAt('opus', frame(40, 0x78), 1 + 6);
+
+		await expect(open(shape as Sealed, key)).rejects.toThrow();
+	});
+
+	it('rejects a changed ciphertext byte', async () => {
+		const { shape, key } = await tamperedAt('opus', frame(40, 0x78), 1 + NONCE_BYTES + 3);
+
+		await expect(open(shape as Sealed, key)).rejects.toThrow();
+	});
+
+	it('rejects a changed tag', async () => {
+		const { shape, key } = await tamperedAt('opus', frame(40, 0x78), -1);
+
+		await expect(open(shape as Sealed, key)).rejects.toThrow();
+	});
+
+	it('rejects a flipped VP8 keyframe bit, because both sides then disagree on the split', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+		const wire = await sealedBytes(frame(200, 0x10), 'vp8', key);
+
+		wire[0] ^= 0x01;
+
+		const shape = parseFrame(wire, 'vp8');
+
+		expect(shape.header).toBe(3);
+		await expect(open(shape as Sealed, key)).rejects.toThrow();
+	});
+});
+
+describe('wrong keys', () => {
+	it('rejects another key and the next key in the chain alike', async () => {
+		const raw = randomKeyRaw();
+		const key = await importMediaKey(raw);
+		const wire = await sealedBytes(frame(40, 0x78), 'opus', key);
+		const shape = parsedSealed(wire, 'opus');
+
+		await expect(open(shape, await importMediaKey(randomKeyRaw()))).rejects.toThrow();
+		await expect(open(shape, await importMediaKey(await ratchetRaw(raw)))).rejects.toThrow();
+		await expect(open(shape, key)).resolves.toBeDefined();
+	});
+
+	it('opens under the advanced key once the sender has advanced', async () => {
+		const raw = randomKeyRaw();
+		const advanced = await ratchetRaw(raw);
+		const wire = await sealedBytes(frame(40, 0x78), 'opus', await importMediaKey(advanced));
+
+		await expect(open(parsedSealed(wire, 'opus'), await importMediaKey(raw))).rejects.toThrow();
+		await expect(open(parsedSealed(wire, 'opus'), await importMediaKey(advanced))).resolves.toBeDefined();
+	});
+});
+
+describe('seal', () => {
+	it('places the nonce between the clear header and the ciphertext', async () => {
+		const key = await importMediaKey(randomKeyRaw());
+		const data = frame(40, 0x78);
+		const nonce = nonceFor(KEY_ID, 9);
+		const wire = await seal(data, 1, key, nonce);
+
+		expect(wire[0]).toBe(data[0]);
+		expect(hex(wire.subarray(1, 1 + NONCE_BYTES))).toBe(hex(nonce));
+		expect(wire.length).toBe(1 + NONCE_BYTES + 39 + GCM_TAG_BYTES);
+	});
+});

--- a/src/utils/e2ee/frameCrypto.ts
+++ b/src/utils/e2ee/frameCrypto.ts
@@ -1,0 +1,97 @@
+import { Bytes } from './crypto';
+
+const subtle = globalThis.crypto.subtle;
+
+export const NONCE_BYTES = 12;
+export const GCM_TAG_BYTES = 16;
+
+// Leading bytes the SFU must read for keyframe detection (must stay clear). Derived from the CODEC
+// (passed in, so identical on sender and receiver) and from the BITSTREAM, never from frame.type.
+// Both ends must compute the same split or every frame fails to authenticate, and frame.type is a
+// field each engine populates for itself rather than something carried on the wire, so it is the
+// wrong thing to key on even where two engines happen to agree.
+export function clearBytes(data: Uint8Array, codec: string): number {
+	if (codec === 'opus') return 1; // audio: Opus TOC byte
+	if (codec === 'vp9') return 0; // VP9: keyframe + layers live in the RTP descriptor
+
+	if (codec === 'vp8') {
+		// VP8 frame tag: P bit (bit 0 of byte 0) = 0 => keyframe (10-byte header), else delta (3).
+		// byte 0 is always within the clear header, so this reads the same on encrypt and decrypt.
+		return (data[0] & 0x01) === 0 ? 10 : 3;
+	}
+
+	return 3; // h264/other: not supported for E2EE, keep a minimal clear header
+}
+
+// 12-byte nonce = keyId(4) ‖ counter(8); also the SFrame header so decrypt is stateless.
+export function nonceFor(keyId: number, counter: number): Bytes {
+	const b = new Uint8Array(NONCE_BYTES);
+	const dv = new DataView(b.buffer);
+
+	dv.setUint32(0, keyId >>> 0);
+	dv.setBigUint64(4, BigInt(counter));
+
+	return b;
+}
+
+// The clear header is authenticated as additional data, so the SFU can read it but cannot change it.
+export async function seal(data: Bytes, header: number, key: CryptoKey, nonce: Bytes): Promise<Bytes> {
+	const clear = data.subarray(0, header);
+	const payload = data.subarray(header);
+	const ct = new Uint8Array(await subtle.encrypt({ name: 'AES-GCM', iv: nonce, additionalData: clear }, key, payload));
+	const out = new Uint8Array(header + NONCE_BYTES + ct.length);
+
+	out.set(clear, 0);
+	out.set(nonce, header);
+	out.set(ct, header + NONCE_BYTES);
+
+	return out;
+}
+
+export type Sealed = { kind: 'sealed'; header: number; keyId: number; nonce: Bytes; clear: Bytes; ct: Bytes };
+export type FrameShape = { kind: 'passthrough'; header: number } | { kind: 'impossible'; header: number } | Sealed;
+
+// A sender emits exactly two shapes: a passthrough frame with nothing past the clear header, or an
+// encrypted one carrying a nonce, a tag and at least one byte of payload. Every size between those
+// is unreachable for a peer, so a frame in that band did not come from one. Passing it on would
+// hand the decoder unauthenticated bytes that an SFU could have injected, and at low Opus bitrates
+// that band is large enough to carry audible audio, so it is reported as impossible instead.
+export function parseFrame(data: Bytes, codec: string): FrameShape {
+	const header = clearBytes(data, codec);
+
+	if (data.length <= header) return { kind: 'passthrough', header };
+	if (data.length < header + NONCE_BYTES + GCM_TAG_BYTES + 1) return { kind: 'impossible', header };
+
+	const nonce = data.subarray(header, header + NONCE_BYTES);
+	const keyId = new DataView(nonce.buffer, nonce.byteOffset, NONCE_BYTES).getUint32(0);
+
+	return {
+		kind: 'sealed',
+		header,
+		keyId,
+		nonce,
+		clear: data.subarray(0, header),
+		ct: data.subarray(header + NONCE_BYTES),
+	};
+}
+
+export async function open(frame: Sealed, key: CryptoKey): Promise<Bytes> {
+	const pt = new Uint8Array(await subtle.decrypt({ name: 'AES-GCM', iv: frame.nonce, additionalData: frame.clear }, key, frame.ct));
+	const out = new Uint8Array(frame.header + pt.length);
+
+	out.set(frame.clear, 0);
+	out.set(pt, frame.header);
+
+	return out;
+}
+
+export type SealResult = { kind: 'passthrough'; header: number } | { kind: 'sealed'; data: Bytes };
+
+// A whole send side step, for tests and for anyone who wants the two decisions in one call.
+export async function sealFrame(data: Bytes, codec: string, key: CryptoKey, keyId: number, counter: number): Promise<SealResult> {
+	const header = clearBytes(data, codec);
+
+	if (data.length <= header) return { kind: 'passthrough', header };
+
+	return { kind: 'sealed', data: await seal(data, header, key, nonceFor(keyId, counter)) };
+}

--- a/src/utils/e2ee/keyStore.test.ts
+++ b/src/utils/e2ee/keyStore.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+	DecEntry,
+	DecryptKeyStore,
+	KEY_NEEDED_AFTER_MISSES,
+	KEY_NEEDED_INTERVAL_MS,
+	KEYS_KEPT_PER_SENDER,
+	KeyNeeded,
+	MAX_RATCHET_STEPS,
+	MISSING_TRACKED,
+} from './keyStore';
+import { Bytes, importMediaKey, randomKeyRaw, ratchetRaw } from './crypto';
+
+const NS = 0xabcdef;
+const OTHER = 0x123456;
+
+const kid = (ns: number, epoch: number): number => (((ns << 8) | (epoch & 0xff)) >>> 0);
+const hex = (bytes: Uint8Array): string => Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+const entry = async (raw: Bytes): Promise<DecEntry> => ({ key: await importMediaKey(raw), raw });
+
+const advance = async (raw: Bytes, steps: number): Promise<Bytes> => {
+	let out = raw;
+
+	for (let i = 0; i < steps; i++) out = await ratchetRaw(out);
+
+	return out;
+};
+
+const makeStore = (now: () => number = () => 0) => {
+	const onKeyNeeded = vi.fn<KeyNeeded>();
+
+	return { store: new DecryptKeyStore(onKeyNeeded, now), onKeyNeeded };
+};
+
+const epochsOf = (store: DecryptKeyStore, ns: number): number[] =>
+	store.knownKeyIds()
+		.filter((k) => (k >>> 8) === ns)
+		.map((k) => k & 0xff);
+
+describe('deriving a sender key we were never sent', () => {
+	it('derives one step and lands on the target id', async () => {
+		const { store } = makeStore();
+		const k0 = randomKeyRaw();
+
+		store.set(kid(NS, 0), await entry(k0));
+
+		const chain = await store.deriveChain(kid(NS, 1));
+
+		expect(chain).toHaveLength(1);
+		expect(chain?.[0].id).toBe(kid(NS, 1));
+		expect(hex(chain![0].entry.raw)).toBe(hex(await ratchetRaw(k0)));
+	});
+
+	it('derives several steps in order', async () => {
+		const { store } = makeStore();
+		const k0 = randomKeyRaw();
+
+		store.set(kid(NS, 0), await entry(k0));
+
+		const chain = await store.deriveChain(kid(NS, 5));
+
+		expect(chain?.map((c) => c.id & 0xff)).toEqual([ 1, 2, 3, 4, 5 ]);
+		expect(hex(chain![4].entry.raw)).toBe(hex(await advance(k0, 5)));
+	});
+
+	it('wraps the epoch at 256', async () => {
+		const { store } = makeStore();
+		const k250 = randomKeyRaw();
+
+		store.set(kid(NS, 250), await entry(k250));
+
+		const chain = await store.deriveChain(kid(NS, 2));
+
+		expect(chain?.map((c) => c.id & 0xff)).toEqual([ 251, 252, 253, 254, 255, 0, 1, 2 ]);
+		expect(hex(chain![7].entry.raw)).toBe(hex(await advance(k250, 8)));
+	});
+
+	it('refuses to derive further than the bound', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+
+		expect(await store.deriveChain(kid(NS, MAX_RATCHET_STEPS))).toHaveLength(MAX_RATCHET_STEPS);
+		expect(await store.deriveChain(kid(NS, MAX_RATCHET_STEPS + 1))).toBeUndefined();
+	});
+
+	it('refuses the same epoch and anything behind it', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 5), await entry(randomKeyRaw()));
+
+		expect(await store.deriveChain(kid(NS, 5))).toBeUndefined();
+		expect(await store.deriveChain(kid(NS, 4))).toBeUndefined();
+	});
+
+	it('never starts from another sender', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(OTHER, 0), await entry(randomKeyRaw()));
+
+		expect(await store.deriveChain(kid(NS, 1))).toBeUndefined();
+	});
+
+	it('starts from the nearest key behind the target', async () => {
+		const { store } = makeStore();
+		const k0 = randomKeyRaw();
+		const k3 = await advance(k0, 3);
+
+		store.set(kid(NS, 0), await entry(k0));
+		store.set(kid(NS, 3), await entry(k3));
+
+		const chain = await store.deriveChain(kid(NS, 4));
+
+		expect(chain).toHaveLength(1);
+		expect(hex(chain![0].entry.raw)).toBe(hex(await ratchetRaw(k3)));
+	});
+});
+
+describe('committing and evicting', () => {
+	it('keeps the target after a maximal catch-up and trims to the window', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+
+		const chain = await store.deriveChain(kid(NS, MAX_RATCHET_STEPS));
+
+		store.commitChain(chain!);
+
+		expect(store.has(kid(NS, MAX_RATCHET_STEPS))).toBe(true);
+		expect(epochsOf(store, NS)).toHaveLength(KEYS_KEPT_PER_SENDER);
+		expect(Math.min(...epochsOf(store, NS))).toBe(MAX_RATCHET_STEPS - KEYS_KEPT_PER_SENDER + 1);
+	});
+
+	it('evicts per sender only', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		for (let e = 0; e < 20; e++) store.set(kid(OTHER, e), await entry(randomKeyRaw()));
+
+		expect(epochsOf(store, OTHER)).toHaveLength(KEYS_KEPT_PER_SENDER);
+		expect(epochsOf(store, NS)).toEqual([ 0 ]);
+	});
+
+	it('moves a re-delivered key to most recent', async () => {
+		const { store } = makeStore();
+
+		for (let e = 0; e < KEYS_KEPT_PER_SENDER; e++) store.set(kid(NS, e), await entry(randomKeyRaw()));
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		store.set(kid(NS, KEYS_KEPT_PER_SENDER), await entry(randomKeyRaw()));
+
+		expect(store.has(kid(NS, 0))).toBe(true);
+		expect(store.has(kid(NS, 1))).toBe(false);
+	});
+
+	it('drops one sender and nobody else', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		store.set(kid(NS, 1), await entry(randomKeyRaw()));
+		store.set(kid(OTHER, 0), await entry(randomKeyRaw()));
+		store.dropNamespace(NS);
+
+		expect(store.knownKeyIds()).toEqual([ kid(OTHER, 0) ]);
+	});
+});
+
+describe('asking for a key we cannot derive', () => {
+	const missMany = (store: DecryptKeyStore, ns: number, times: number): void => {
+		for (let i = 0; i < times; i++) store.missed(ns);
+	};
+
+	it('asks after a sustained run of misses, then no more than once per interval', () => {
+		let now = 0;
+		const { store, onKeyNeeded } = makeStore(() => now);
+
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES - 1);
+		expect(onKeyNeeded).not.toHaveBeenCalled();
+
+		store.missed(NS);
+		expect(onKeyNeeded).toHaveBeenCalledTimes(1);
+		expect(onKeyNeeded).toHaveBeenCalledWith(NS);
+
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES);
+		expect(onKeyNeeded).toHaveBeenCalledTimes(1);
+
+		now = KEY_NEEDED_INTERVAL_MS;
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES);
+		expect(onKeyNeeded).toHaveBeenCalledTimes(2);
+	});
+
+	it('starts over once a frame decrypts or a key is delivered or the sender leaves', async () => {
+		const { store, onKeyNeeded } = makeStore();
+
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES - 1);
+		store.decrypted(NS);
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES - 1);
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES - 1);
+		store.dropNamespace(NS);
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES - 1);
+
+		expect(onKeyNeeded).not.toHaveBeenCalled();
+	});
+
+	it('never asks for namespaces that only ever appear once', () => {
+		const { store, onKeyNeeded } = makeStore();
+
+		for (let i = 0; i < 100000; i++) store.missed((i * 2654435761) >>> 8);
+
+		expect(onKeyNeeded).not.toHaveBeenCalled();
+	});
+
+	it('still asks for a real sender while invented namespaces churn alongside it', () => {
+		const { store, onKeyNeeded } = makeStore();
+
+		for (let i = 0; i < KEY_NEEDED_AFTER_MISSES; i++) {
+			store.missed(NS);
+			store.missed((i * 7919) >>> 8);
+		}
+
+		expect(onKeyNeeded).toHaveBeenCalledTimes(1);
+		expect(onKeyNeeded).toHaveBeenCalledWith(NS);
+	});
+
+	it('forgets a sender that has not been missed recently', () => {
+		const { store, onKeyNeeded } = makeStore();
+
+		store.missed(NS);
+		for (let i = 1; i <= MISSING_TRACKED; i++) store.missed(OTHER + i);
+		missMany(store, NS, KEY_NEEDED_AFTER_MISSES - 1);
+
+		expect(onKeyNeeded).not.toHaveBeenCalled();
+
+		store.missed(NS);
+		expect(onKeyNeeded).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/utils/e2ee/keyStore.test.ts
+++ b/src/utils/e2ee/keyStore.test.ts
@@ -164,6 +164,37 @@ describe('committing and evicting', () => {
 	});
 });
 
+describe('a key id whose derivation failed to authenticate', () => {
+	it('is not derived again until a key for that sender is delivered', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		expect(await store.deriveChain(kid(NS, 1))).toHaveLength(1);
+
+		store.deriveFailed(kid(NS, 1));
+		expect(await store.deriveChain(kid(NS, 1))).toBeUndefined();
+		expect(await store.deriveChain(kid(NS, 2))).toHaveLength(2);
+
+		store.set(kid(NS, 1), await entry(randomKeyRaw()));
+		expect(store.has(kid(NS, 1))).toBe(true);
+		expect(await store.deriveChain(kid(NS, 2))).toHaveLength(1);
+	});
+
+	it('is forgotten when the sender leaves, and never affects another sender', async () => {
+		const { store } = makeStore();
+
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		store.set(kid(OTHER, 0), await entry(randomKeyRaw()));
+		store.deriveFailed(kid(NS, 1));
+
+		expect(await store.deriveChain(kid(OTHER, 1))).toHaveLength(1);
+
+		store.dropNamespace(NS);
+		store.set(kid(NS, 0), await entry(randomKeyRaw()));
+		expect(await store.deriveChain(kid(NS, 1))).toHaveLength(1);
+	});
+});
+
 describe('asking for a key we cannot derive', () => {
 	const missMany = (store: DecryptKeyStore, ns: number, times: number): void => {
 		for (let i = 0; i < times; i++) store.missed(ns);

--- a/src/utils/e2ee/keyStore.test.ts
+++ b/src/utils/e2ee/keyStore.test.ts
@@ -172,10 +172,12 @@ describe('a key id whose derivation failed to authenticate', () => {
 		expect(await store.deriveChain(kid(NS, 1))).toHaveLength(1);
 
 		store.deriveFailed(kid(NS, 1));
+		expect(store.isUndeliverable(kid(NS, 1))).toBe(true);
 		expect(await store.deriveChain(kid(NS, 1))).toBeUndefined();
 		expect(await store.deriveChain(kid(NS, 2))).toHaveLength(2);
 
 		store.set(kid(NS, 1), await entry(randomKeyRaw()));
+		expect(store.isUndeliverable(kid(NS, 1))).toBe(false);
 		expect(store.has(kid(NS, 1))).toBe(true);
 		expect(await store.deriveChain(kid(NS, 2))).toHaveLength(1);
 	});

--- a/src/utils/e2ee/keyStore.ts
+++ b/src/utils/e2ee/keyStore.ts
@@ -39,6 +39,13 @@ export type KeyNeeded = (namespace: number) => void;
 export class DecryptKeyStore {
 	readonly keys = new Map<number, DecEntry>();
 	readonly #missing = new Map<number, { misses: number; asked?: number }>();
+	// Key ids whose derived key failed to authenticate. The sender replaced its key rather than
+	// advancing it, so no derivation from what we hold can ever open these frames, and trying again
+	// on every frame is pure cost: three WebCrypto round trips per frame, at frame rate, for as long
+	// as the replacement takes to arrive. On Firefox that load was enough to hold up the worker's own
+	// message queue, so the replacement itself was delayed by the work of waiting for it. Cleared for
+	// a namespace whenever a key for it is delivered or dropped.
+	readonly #undeliverable = new Set<number>();
 	readonly #onKeyNeeded: KeyNeeded;
 	readonly #now: () => number;
 
@@ -69,6 +76,7 @@ export class DecryptKeyStore {
 		this.keys.set(keyId, entry);
 		this.evictOldKeys(keyId >>> 8);
 		this.#missing.delete(keyId >>> 8);
+		this.#forgetFailures(keyId >>> 8);
 	}
 
 	// A peer left: nothing they sent can still be decodable, so drop their keys outright.
@@ -77,10 +85,20 @@ export class DecryptKeyStore {
 			this.keys.delete(k);
 
 		this.#missing.delete(namespace);
+		this.#forgetFailures(namespace);
 	}
 
 	decrypted(namespace: number): void {
 		this.#missing.delete(namespace);
+	}
+
+	deriveFailed(keyId: number): void {
+		this.#undeliverable.add(keyId);
+	}
+
+	#forgetFailures(namespace: number): void {
+		for (const k of [ ...this.#undeliverable ].filter((k2) => (k2 >>> 8) === namespace))
+			this.#undeliverable.delete(k);
 	}
 
 	missed(namespace: number): void {
@@ -109,6 +127,8 @@ export class DecryptKeyStore {
 	// authenticated under it, so a wrong guess (the sender replaced its key) and a forged keyId both
 	// leave the key map alone instead of evicting keys that work.
 	async deriveChain(keyId: number): Promise<Chain | undefined> {
+		if (this.#undeliverable.has(keyId)) return undefined;
+
 		const namespace = keyId >>> 8;
 		const target = keyId & 0xff;
 		let from: { raw: Bytes; steps: number } | undefined;

--- a/src/utils/e2ee/keyStore.ts
+++ b/src/utils/e2ee/keyStore.ts
@@ -1,0 +1,160 @@
+import { Bytes, importMediaKey, ratchetRaw } from './crypto';
+
+// The bytes are kept alongside the key because a sender may advance its key rather than replace it,
+// and deriving the next one needs material, not a key that can only be used.
+export type DecEntry = { key: CryptoKey; raw: Bytes };
+
+export type Chain = Array<{ id: number; entry: DecEntry }>;
+
+// Keys a sender may still have frames in flight under. Rotations are not coalesced, so peers leaving
+// together produce several in quick succession, and a sender advancing its key on each arrival adds
+// more. Sixteen is what LiveKit keeps for the same reason and costs nothing worth counting.
+export const KEYS_KEPT_PER_SENDER = 16;
+
+// How far past a key we hold we are willing to derive. A sender advances once per arrival and a
+// receiver only follows by decrypting a frame, so anyone the SFU was not forwarding that sender to
+// falls behind by a step per arrival they missed. Deriving is one hash per step, so a generous
+// ceiling costs little, and what it buys is a bound on the work a forged keyId can demand. Falling
+// further behind than this is not fatal: it is reported and recovered by asking the sender.
+export const MAX_RATCHET_STEPS = 32;
+
+// A sender we cannot decrypt at all: either their key never reached us, or we have fallen further
+// behind their advances than we will derive. Neither resolves by itself, so after a sustained run of
+// failures the sender is named to the caller, which knows how to ask them for a key. Reported rather
+// than acted on here because the worker only ever sees namespaces, never peers.
+// Roughly three seconds of a stream. Long enough that a key still in flight during a busy join is not
+// mistaken for a missing one, short enough that a genuinely stuck participant recovers quickly.
+export const KEY_NEEDED_AFTER_MISSES = 90;
+export const KEY_NEEDED_INTERVAL_MS = 5000;
+
+// A namespace comes out of the frame, so a stream we are reading at the wrong offset yields a fresh
+// invented one every frame. Those never repeat and so never reach the threshold, but they would grow
+// the tracker without limit, hence a cap. Entries are re-inserted on each miss so the order tracks
+// recency and the one dropped is the one least recently missed.
+export const MISSING_TRACKED = 64;
+
+// eslint-disable-next-line no-unused-vars
+export type KeyNeeded = (namespace: number) => void;
+
+export class DecryptKeyStore {
+	readonly keys = new Map<number, DecEntry>();
+	readonly #missing = new Map<number, { misses: number; asked?: number }>();
+	readonly #onKeyNeeded: KeyNeeded;
+	readonly #now: () => number;
+
+	constructor(onKeyNeeded: KeyNeeded, now: () => number = Date.now) {
+		this.#onKeyNeeded = onKeyNeeded;
+		this.#now = now;
+	}
+
+	get size(): number {
+		return this.keys.size;
+	}
+
+	has(keyId: number): boolean {
+		return this.keys.has(keyId);
+	}
+
+	get(keyId: number): DecEntry | undefined {
+		return this.keys.get(keyId);
+	}
+
+	knownKeyIds(): number[] {
+		return [ ...this.keys.keys() ];
+	}
+
+	// Delete first so the Map's insertion order tracks recency, which is what eviction reads.
+	set(keyId: number, entry: DecEntry): void {
+		this.keys.delete(keyId);
+		this.keys.set(keyId, entry);
+		this.evictOldKeys(keyId >>> 8);
+		this.#missing.delete(keyId >>> 8);
+	}
+
+	// A peer left: nothing they sent can still be decodable, so drop their keys outright.
+	dropNamespace(namespace: number): void {
+		for (const k of [ ...this.keys.keys() ].filter((k2) => (k2 >>> 8) === namespace))
+			this.keys.delete(k);
+
+		this.#missing.delete(namespace);
+	}
+
+	decrypted(namespace: number): void {
+		this.#missing.delete(namespace);
+	}
+
+	missed(namespace: number): void {
+		const state = this.#missing.get(namespace) ?? { misses: 0 };
+
+		state.misses++;
+		this.#missing.delete(namespace);
+		this.#missing.set(namespace, state);
+
+		for (const stale of [ ...this.#missing.keys() ].slice(0, Math.max(0, this.#missing.size - MISSING_TRACKED)))
+			this.#missing.delete(stale);
+
+		if (state.misses < KEY_NEEDED_AFTER_MISSES) return;
+
+		const now = this.#now();
+
+		if (state.asked !== undefined && now - state.asked < KEY_NEEDED_INTERVAL_MS) return;
+
+		state.asked = now;
+		state.misses = 0;
+		this.#onKeyNeeded(namespace);
+	}
+
+	// A keyId we were never sent may still be one the sender derived rather than replaced, and if so
+	// we can derive it too. Nothing is stored here: the caller commits the chain only once a frame has
+	// authenticated under it, so a wrong guess (the sender replaced its key) and a forged keyId both
+	// leave the key map alone instead of evicting keys that work.
+	async deriveChain(keyId: number): Promise<Chain | undefined> {
+		const namespace = keyId >>> 8;
+		const target = keyId & 0xff;
+		let from: { raw: Bytes; steps: number } | undefined;
+
+		// Nearest key behind the target, so we derive as few steps as possible. Epochs wrap at 256,
+		// which is what the masked subtraction is for.
+		for (const [ id, held ] of this.keys) {
+			if ((id >>> 8) !== namespace) continue;
+
+			const steps = (target - (id & 0xff)) & 0xff;
+
+			if (steps < 1 || steps > MAX_RATCHET_STEPS) continue;
+			if (!from || steps < from.steps) from = { raw: held.raw, steps };
+		}
+
+		if (!from) return undefined;
+
+		const chain: Chain = [];
+		let raw = from.raw;
+
+		for (let i = from.steps - 1; i >= 0; i--) {
+			raw = await ratchetRaw(raw);
+			chain.push({ id: ((namespace << 8) | ((target - i) & 0xff)) >>> 0, entry: { key: await importMediaKey(raw), raw } });
+		}
+
+		return chain;
+	}
+
+	commitChain(chain: Chain): void {
+		for (const { id, entry } of chain) {
+			this.keys.delete(id);
+			this.keys.set(id, entry);
+		}
+
+		this.evictOldKeys(chain[0].id >>> 8);
+	}
+
+	// keyId is namespace(24 bits) | epoch(8 bits), and the namespace identifies the sender, so keys can
+	// be aged out per sender without the worker knowing anything about peers. Without this the map
+	// grows for the life of the session and every key ever received stays valid, so an SFU could
+	// replay old frames indefinitely. It also makes the epoch wrapping after 256 rotations a
+	// non-event: no key old enough to collide with a reused id is still here.
+	evictOldKeys(namespace: number): void {
+		const mine = [ ...this.keys.keys() ].filter((k) => (k >>> 8) === namespace);
+
+		for (const stale of mine.slice(0, Math.max(0, mine.length - KEYS_KEPT_PER_SENDER)))
+			this.keys.delete(stale);
+	}
+}

--- a/src/utils/e2ee/keyStore.ts
+++ b/src/utils/e2ee/keyStore.ts
@@ -96,6 +96,10 @@ export class DecryptKeyStore {
 		this.#undeliverable.add(keyId);
 	}
 
+	isUndeliverable(keyId: number): boolean {
+		return this.#undeliverable.has(keyId);
+	}
+
 	#forgetFailures(namespace: number): void {
 		for (const k of [ ...this.#undeliverable ].filter((k2) => (k2 >>> 8) === namespace))
 			this.#undeliverable.delete(k);

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -235,11 +235,13 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 		// A keyId we hold no key for and cannot derive one for. Either the sender's key never reached
 		// us, or we have fallen further behind their advances than we will derive, or this is not a
 		// keyId at all because the clear byte count disagrees and we are reading ciphertext as a
-		// header. The first two are recoverable and the count below is what starts that.
+		// header. The first two are recoverable and the count below is what starts that. A key we
+		// already failed to derive is the ordinary gap after a departure, waiting for the replacement
+		// to be delivered, so it is reported under its own name rather than as something unknown.
 		if (!key) {
 			dec.missed(namespace);
 
-			return drop(diag, 'unknownKeyId', { keyId, knownKeyIds: dec.knownKeyIds(), header });
+			return drop(diag, dec.isUndeliverable(keyId) ? 'awaitingReplacement' : 'unknownKeyId', { keyId, knownKeyIds: dec.knownKeyIds(), header });
 		}
 		const out = await open(shape, key);
 

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -4,27 +4,14 @@
 // Codec-aware clear header (Phase 0, source-proven vs mediasoup): VP8 10/3, VP9 0, Opus audio 1.
 // Keys arrive via postMessage (CryptoKey is structured-cloneable); never leaves the worker.
 
-const subtle = (globalThis as any).crypto.subtle;
+import { DecryptKeyStore } from './keyStore';
+import { clearBytes, nonceFor, open, parseFrame, seal } from './frameCrypto';
 
-const enc: { key?: CryptoKey; keyId: number; counter: number } = { keyId: 0, counter: 0 };
-const dec = { keys: new Map<number, CryptoKey>() };
-
-// Keys a sender may still have frames in flight under. Two would cover a single rotation, but
-// rotations are not coalesced, so two peers leaving together produce two in quick succession and
-// frames under the oldest key would be dropped. Three covers that at the cost of one CryptoKey.
-const KEYS_KEPT_PER_SENDER = 3;
-
-// keyId is namespace(24 bits) | epoch(8 bits), and the namespace identifies the sender, so keys can
-// be aged out per sender without the worker knowing anything about peers. Without this the map grows
-// for the life of the session and every key ever received stays valid, so an SFU could replay old
-// frames indefinitely. It also makes the epoch wrapping after 256 rotations a non-event: no key old
-// enough to collide with a reused id is still here.
-function evictOldKeys(namespace: number): void {
-	const mine = [ ...dec.keys.keys() ].filter((k) => (k >>> 8) === namespace);
-
-	for (const stale of mine.slice(0, Math.max(0, mine.length - KEYS_KEPT_PER_SENDER)))
-		dec.keys.delete(stale);
-}
+// `used` records whether anything has actually been encrypted under the current key. Advancing on a
+// newcomer's arrival exists to keep them from reading what came before, so it is only worth anything
+// once something has been sent under the key being left behind.
+const enc: { key?: CryptoKey; keyId: number; counter: number; used: boolean } = { keyId: 0, counter: 0, used: false };
+const dec = new DecryptKeyStore((namespace) => report({ level: 'debug', event: 'keyNeeded', namespace }));
 const encTransformers: any[] = [];
 const decTransformers: any[] = [];
 
@@ -36,8 +23,6 @@ const decTransformers: any[] = [];
 // first few frames of each stream in full, then a rolling counter summary.
 const DEBUG_FRAMES = 3;
 const SUMMARY_MS = 5000;
-const NONCE_BYTES = 12;
-const GCM_TAG_BYTES = 16;
 
 type Diag = {
 	id: number;
@@ -140,43 +125,12 @@ function tick(diag: Diag): void {
 	diag.windowOk = diag.ok;
 }
 
-// Leading bytes the SFU must read for keyframe detection (must stay clear). Derived from the CODEC
-// (passed in, so identical on sender and receiver) and from the BITSTREAM, never from frame.type.
-// Both ends must compute the same split or every frame fails to authenticate, and frame.type is a
-// field each engine populates for itself rather than something carried on the wire, so it is the
-// wrong thing to key on even where two engines happen to agree.
-function clearBytes(frame: any, codec: string): number {
-	if (codec === 'opus') return 1; // audio: Opus TOC byte
-	if (codec === 'vp9') return 0; // VP9: keyframe + layers live in the RTP descriptor
-
-	if (codec === 'vp8') {
-		// VP8 frame tag: P bit (bit 0 of byte 0) = 0 => keyframe (10-byte header), else delta (3).
-		// byte 0 is always within the clear header, so this reads the same on encrypt and decrypt.
-		const b0 = new Uint8Array(frame.data, 0, 1)[0];
-
-		return (b0 & 0x01) === 0 ? 10 : 3;
-	}
-
-	return 3; // h264/other: not supported for E2EE, keep a minimal clear header
-}
-
-// 12-byte nonce = keyId(4) ‖ counter(8); also the SFrame header so decrypt is stateless.
-function nonceFor(keyId: number, counter: number): Uint8Array {
-	const b = new Uint8Array(12);
-	const dv = new DataView(b.buffer);
-
-	dv.setUint32(0, keyId >>> 0);
-	dv.setBigUint64(4, BigInt(counter));
-	
-	return b;
-}
-
 async function encrypt(frame: any, controller: any, codec: string, diag: Diag): Promise<void> {
 	diag.seen++;
 	if (!enc.key) return drop(diag, 'noEncKey'); // no key yet -> don't emit cleartext
 	try {
-		const header = clearBytes(frame, codec);
 		const data = new Uint8Array(frame.data);
+		const header = clearBytes(data, codec);
 		// A frame with nothing past the clear header (Opus DTX/silence) would be authenticated with a
 		// zero-length AAD here while the receiver reads a header-length AAD, so GCM would reject every
 		// one of them. Nothing in such a frame is secret, so pass it through untouched.
@@ -190,8 +144,6 @@ async function encrypt(frame: any, controller: any, codec: string, diag: Diag): 
 			return;
 		}
 
-		const clear = data.subarray(0, header);
-		const payload = data.subarray(header);
 		const nonce = nonceFor(enc.keyId, enc.counter++);
 
 		if (diag.seen <= DEBUG_FRAMES) {
@@ -208,14 +160,14 @@ async function encrypt(frame: any, controller: any, codec: string, diag: Diag): 
 			});
 		}
 
-		const ct = new Uint8Array(await subtle.encrypt({ name: 'AES-GCM', iv: nonce, additionalData: clear }, enc.key, payload));
-		const out = new Uint8Array(header + 12 + ct.length);
-
-		out.set(clear, 0);
-		out.set(nonce, header);
-		out.set(ct, header + 12);
-		frame.data = out.buffer;
+		frame.data = (await seal(data, header, enc.key, nonce)).buffer;
 		diag.ok++;
+
+		if (!enc.used) {
+			enc.used = true;
+			report({ level: 'debug', event: 'encKeyUsed', keyId: enc.keyId });
+		}
+
 		// Proof that this stream is genuinely being encrypted, not merely that a transform was attached.
 		if (diag.ok === 1) report({ level: 'debug', id: diag.id, op: 'encrypt', codec, event: 'firstFrame' });
 		markHandled(diag, 'encrypt', codec);
@@ -228,17 +180,17 @@ async function encrypt(frame: any, controller: any, codec: string, diag: Diag): 
 
 async function decrypt(frame: any, controller: any, codec: string, diag: Diag): Promise<void> {
 	diag.seen++;
-	if (dec.keys.size === 0) return drop(diag, 'noDecKeys');
-	try {
-		const header = clearBytes(frame, codec);
-		const data = new Uint8Array(frame.data);
-		// A sender emits exactly two shapes: a passthrough frame with nothing past the clear header, or
-		// an encrypted one carrying a nonce, a tag and at least one byte of payload. Every size between
-		// those is unreachable for a peer, so a frame in that band did not come from one. Passing it on
-		// would hand the decoder unauthenticated bytes that an SFU could have injected, and at low Opus
-		// bitrates that band is large enough to carry audible audio, so it is dropped instead.
+	if (dec.size === 0) return drop(diag, 'noDecKeys');
 
-		if (data.length <= header) {
+	let derived = false;
+	let namespace = -1;
+
+	try {
+		const data = new Uint8Array(frame.data);
+		const shape = parseFrame(data, codec);
+		const { header } = shape;
+
+		if (shape.kind === 'passthrough') {
 			diag.passed++;
 			markHandled(diag, 'decrypt', codec);
 			controller.enqueue(frame);
@@ -247,17 +199,21 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 			return;
 		}
 
-		if (data.length < header + NONCE_BYTES + GCM_TAG_BYTES + 1) {
+		if (shape.kind === 'impossible') {
 			drop(diag, 'impossibleLength', { bytes: data.length, header });
 			tick(diag);
 
 			return;
 		}
 
-		const clear = data.subarray(0, header);
-		const nonce = data.subarray(header, header + 12);
-		const keyId = new DataView(nonce.buffer, nonce.byteOffset, 12).getUint32(0);
-		const key = dec.keys.get(keyId);
+		const { keyId } = shape;
+
+		namespace = keyId >>> 8;
+
+		const chain = dec.has(keyId) ? undefined : await dec.deriveChain(keyId);
+		const key = chain ? chain[chain.length - 1].entry.key : dec.get(keyId)?.key;
+
+		derived = Boolean(chain);
 
 		if (diag.seen <= DEBUG_FRAMES) {
 			report({
@@ -269,21 +225,30 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 				header,
 				keyId,
 				haveKey: Boolean(key),
-				knownKeyIds: [ ...dec.keys.keys() ],
+				derived,
+				knownKeyIds: dec.knownKeyIds(),
 				wireHead: hex(data, Math.min(16, data.length)),
 				...frameShape(frame)
 			});
 		}
 
-		// An unknown keyId is the signature of a clear-byte disagreement between sender and receiver:
-		// the nonce is read at the wrong offset, so this is ciphertext being parsed as a header.
-		if (!key) return drop(diag, 'unknownKeyId', { keyId, knownKeyIds: [ ...dec.keys.keys() ], header });
-		const ct = data.subarray(header + 12);
-		const pt = new Uint8Array(await subtle.decrypt({ name: 'AES-GCM', iv: nonce, additionalData: clear }, key, ct));
-		const out = new Uint8Array(header + pt.length);
+		// A keyId we hold no key for and cannot derive one for. Either the sender's key never reached
+		// us, or we have fallen further behind their advances than we will derive, or this is not a
+		// keyId at all because the clear byte count disagrees and we are reading ciphertext as a
+		// header. The first two are recoverable and the count below is what starts that.
+		if (!key) {
+			dec.missed(namespace);
 
-		out.set(clear, 0);
-		out.set(pt, header);
+			return drop(diag, 'unknownKeyId', { keyId, knownKeyIds: dec.knownKeyIds(), header });
+		}
+		const out = await open(shape, key);
+
+		// Authenticated, so a derived key was the right guess and is worth keeping. Anything that fails
+		// past this point is not the derivation's doing, so stop attributing it to one.
+		derived = false;
+		dec.decrypted(namespace);
+		if (chain) dec.commitChain(chain);
+
 		frame.data = out.buffer;
 		diag.ok++;
 		if (diag.ok === 1) report({ level: 'debug', id: diag.id, op: 'decrypt', codec, event: 'firstFrame' });
@@ -291,7 +256,15 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 		controller.enqueue(frame);
 	} catch (error) {
 		// Correct keyId but failed authentication: same key, different clear/ciphertext split.
-		drop(diag, 'gcmAuthFailed', { error: String(error), bytes: frame.data?.byteLength, header: clearBytes(frame, codec) });
+		if (!derived) drop(diag, 'gcmAuthFailed', { error: String(error), bytes: frame.data?.byteLength, header: clearBytes(new Uint8Array(frame.data), codec) });
+
+		// A derived key that does not authenticate means the sender replaced its key rather than
+		// advancing it, which is what a departure does. Usually the replacement is already on its way,
+		// so this is a short gap, and the count is there for when it is not.
+		else {
+			dec.missed(namespace);
+			drop(diag, 'ratchetMiss', { bytes: frame.data?.byteLength });
+		}
 	}
 	tick(diag);
 }
@@ -315,24 +288,20 @@ function requestKeyFrames(transformers: any[], method: 'generateKeyFrame' | 'sen
 	const m: any = e.data;
 
 	if (m.type === 'encKey') {
-		enc.key = m.key; enc.keyId = m.keyId >>> 0; enc.counter = 0;
-		report({ level: 'debug', event: 'encKey', keyId: enc.keyId });
-		// Our key changed (rotation) -> emit a fresh keyframe so receivers re-sync.
-		requestKeyFrames(encTransformers, 'generateKeyFrame');
+		enc.key = m.key; enc.keyId = m.keyId >>> 0; enc.counter = 0; enc.used = false;
+		report({ level: 'debug', event: 'encKey', keyId: enc.keyId, ratcheted: Boolean(m.ratcheted) });
+		// A replaced key needs a fresh keyframe so receivers re-sync. An advanced one does not, since
+		// receivers derive it and keep decoding, and forcing one per arrival would spike every camera
+		// in the room at exactly the moment people are joining.
+		if (!m.ratcheted) requestKeyFrames(encTransformers, 'generateKeyFrame');
 	} else if (m.type === 'dropKeys') {
-		// A peer left: nothing they sent can still be decodable, so drop their keys outright.
-		for (const k of [ ...dec.keys.keys() ].filter((k2) => (k2 >>> 8) === (m.namespace >>> 0)))
-			dec.keys.delete(k);
-
-		report({ level: 'debug', event: 'dropKeys', namespace: m.namespace >>> 0, knownKeyIds: [ ...dec.keys.keys() ] });
+		dec.dropNamespace(m.namespace >>> 0);
+		report({ level: 'debug', event: 'dropKeys', namespace: m.namespace >>> 0, knownKeyIds: dec.knownKeyIds() });
 	} else if (m.type === 'decKey') {
 		const keyId = m.keyId >>> 0;
 
-		// Delete first so the Map's insertion order tracks recency, which is what eviction reads.
-		dec.keys.delete(keyId);
-		dec.keys.set(keyId, m.key);
-		evictOldKeys(keyId >>> 8);
-		report({ level: 'debug', event: 'decKey', keyId, knownKeyIds: [ ...dec.keys.keys() ] });
+		dec.set(keyId, { key: m.key, raw: m.raw });
+		report({ level: 'debug', event: 'decKey', keyId, knownKeyIds: dec.knownKeyIds() });
 		// A remote key arrived/rotated -> request a keyframe so our decoder starts clean.
 		requestKeyFrames(decTransformers, 'sendKeyFrameRequest');
 	}

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -8,6 +8,22 @@ const subtle = (globalThis as any).crypto.subtle;
 
 const enc: { key?: CryptoKey; keyId: number; counter: number } = { keyId: 0, counter: 0 };
 const dec = { keys: new Map<number, CryptoKey>() };
+
+// Keys a sender may still have frames in flight under. Rotation is seamless because the receiver
+// keeps the previous key while the new one takes over, so two is all that is ever needed.
+const KEYS_KEPT_PER_SENDER = 2;
+
+// keyId is namespace(24 bits) | epoch(8 bits), and the namespace identifies the sender, so keys can
+// be aged out per sender without the worker knowing anything about peers. Without this the map grows
+// for the life of the session and every key ever received stays valid, so an SFU could replay old
+// frames indefinitely. It also makes the epoch wrapping after 256 rotations a non-event: no key old
+// enough to collide with a reused id is still here.
+function evictOldKeys(namespace: number): void {
+	const mine = [ ...dec.keys.keys() ].filter((k) => (k >>> 8) === namespace);
+
+	for (const stale of mine.slice(0, Math.max(0, mine.length - KEYS_KEPT_PER_SENDER)))
+		dec.keys.delete(stale);
+}
 const encTransformers: any[] = [];
 const decTransformers: any[] = [];
 
@@ -302,9 +318,20 @@ function requestKeyFrames(transformers: any[], method: 'generateKeyFrame' | 'sen
 		report({ level: 'debug', event: 'encKey', keyId: enc.keyId });
 		// Our key changed (rotation) -> emit a fresh keyframe so receivers re-sync.
 		requestKeyFrames(encTransformers, 'generateKeyFrame');
+	} else if (m.type === 'dropKeys') {
+		// A peer left: nothing they sent can still be decodable, so drop their keys outright.
+		for (const k of [ ...dec.keys.keys() ].filter((k2) => (k2 >>> 8) === (m.namespace >>> 0)))
+			dec.keys.delete(k);
+
+		report({ level: 'debug', event: 'dropKeys', namespace: m.namespace >>> 0, knownKeyIds: [ ...dec.keys.keys() ] });
 	} else if (m.type === 'decKey') {
-		dec.keys.set(m.keyId >>> 0, m.key);
-		report({ level: 'debug', event: 'decKey', keyId: m.keyId >>> 0, knownKeyIds: [ ...dec.keys.keys() ] });
+		const keyId = m.keyId >>> 0;
+
+		// Delete first so the Map's insertion order tracks recency, which is what eviction reads.
+		dec.keys.delete(keyId);
+		dec.keys.set(keyId, m.key);
+		evictOldKeys(keyId >>> 8);
+		report({ level: 'debug', event: 'decKey', keyId, knownKeyIds: [ ...dec.keys.keys() ] });
 		// A remote key arrived/rotated -> request a keyframe so our decoder starts clean.
 		requestKeyFrames(decTransformers, 'sendKeyFrameRequest');
 	}

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -215,12 +215,23 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 	try {
 		const header = clearBytes(frame, codec);
 		const data = new Uint8Array(frame.data);
-		// Mirror of the sender's short-frame passthrough: anything below this cannot be one of ours.
+		// A sender emits exactly two shapes: a passthrough frame with nothing past the clear header, or
+		// an encrypted one carrying a nonce, a tag and at least one byte of payload. Every size between
+		// those is unreachable for a peer, so a frame in that band did not come from one. Passing it on
+		// would hand the decoder unauthenticated bytes that an SFU could have injected, and at low Opus
+		// bitrates that band is large enough to carry audible audio, so it is dropped instead.
 
-		if (data.length < header + NONCE_BYTES + GCM_TAG_BYTES) {
+		if (data.length <= header) {
 			diag.passed++;
 			markHandled(diag, 'decrypt', codec);
 			controller.enqueue(frame);
+			tick(diag);
+
+			return;
+		}
+
+		if (data.length < header + NONCE_BYTES + GCM_TAG_BYTES + 1) {
+			drop(diag, 'impossibleLength', { bytes: data.length, header });
 			tick(diag);
 
 			return;

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -184,6 +184,7 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 
 	let derived = false;
 	let namespace = -1;
+	let keyId = 0;
 
 	try {
 		const data = new Uint8Array(frame.data);
@@ -206,8 +207,7 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 			return;
 		}
 
-		const { keyId } = shape;
-
+		keyId = shape.keyId;
 		namespace = keyId >>> 8;
 
 		const chain = dec.has(keyId) ? undefined : await dec.deriveChain(keyId);
@@ -262,6 +262,7 @@ async function decrypt(frame: any, controller: any, codec: string, diag: Diag): 
 		// advancing it, which is what a departure does. Usually the replacement is already on its way,
 		// so this is a short gap, and the count is there for when it is not.
 		else {
+			dec.deriveFailed(keyId);
 			dec.missed(namespace);
 			drop(diag, 'ratchetMiss', { bytes: frame.data?.byteLength });
 		}

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -9,9 +9,10 @@ const subtle = (globalThis as any).crypto.subtle;
 const enc: { key?: CryptoKey; keyId: number; counter: number } = { keyId: 0, counter: 0 };
 const dec = { keys: new Map<number, CryptoKey>() };
 
-// Keys a sender may still have frames in flight under. Rotation is seamless because the receiver
-// keeps the previous key while the new one takes over, so two is all that is ever needed.
-const KEYS_KEPT_PER_SENDER = 2;
+// Keys a sender may still have frames in flight under. Two would cover a single rotation, but
+// rotations are not coalesced, so two peers leaving together produce two in quick succession and
+// frames under the oldest key would be dropped. Three covers that at the cost of one CryptoKey.
+const KEYS_KEPT_PER_SENDER = 3;
 
 // keyId is namespace(24 bits) | epoch(8 bits), and the namespace identifies the sender, so keys can
 // be aged out per sender without the worker knowing anything about peers. Without this the map grows

--- a/src/utils/e2ee/sframeWorker.ts
+++ b/src/utils/e2ee/sframeWorker.ts
@@ -320,7 +320,22 @@ const STALL_CHECK_MS = 5000;
 	const t = event?.transformer;
 	const op = t?.options?.operation;
 	const codec = t?.options?.codec;
-	const diag: Diag = { id: ++diagSeq, op, codec, seen: 0, ok: 0, passed: 0, drops: {}, windowDrops: {}, windowSeen: 0, windowOk: 0, nextSummary: 0 };
+	// The main thread assigns the id so it can tell which transform a report belongs to and release
+	// that specific sender. Fall back to a local counter if it ever attaches without one.
+	const tid = t?.options?.tid;
+	const diag: Diag = {
+		id: typeof tid === 'number' ? tid : ++diagSeq,
+		op,
+		codec,
+		seen: 0,
+		ok: 0,
+		passed: 0,
+		drops: {},
+		windowDrops: {},
+		windowSeen: 0,
+		windowOk: 0,
+		nextSummary: 0
+	};
 
 	report({
 		level: 'debug',

--- a/src/utils/mediaSender.tsx
+++ b/src/utils/mediaSender.tsx
@@ -7,14 +7,9 @@ import { SignalingService } from '../services/signalingService';
 import { VolumeWatcher } from './volumeWatcher';
 import hark from 'hark';
 import { Logger } from './Logger';
+import { chooseSendCodec, isProtectableCodec } from './e2ee/codecChoice';
 
 const logger = new Logger('MediaSender');
-
-// Codecs the E2EE worker can split correctly. Opus and VP8/VP9 have a fixed or cheaply derived clear
-// header, so the SFU keeps what it needs for forwarding and the rest is encrypted. H264 does not: the
-// browser packetizes NAL units AFTER our transform has run, so encrypting past a fixed offset leaves
-// the packetizer walking ciphertext and the stream is broken rather than protected.
-const E2EE_PROTECTABLE_CODEC = /^(audio\/opus|video\/vp8|video\/vp9)$/i;
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export declare interface MediaSender {
@@ -323,11 +318,7 @@ export class MediaSender extends EventEmitter {
 
 		const sendCodecs = this.mediaService.sendRtpCapabilities?.codecs;
 
-		// With E2EE on, choose a codec the worker can protect instead of leaving it to negotiation,
-		// which is free to settle on H264. Without E2EE this keeps the previous behaviour exactly.
-		const preferredCodec = holdForE2ee && clonedTrack?.kind === 'video'
-			? sendCodecs?.find((c) => E2EE_PROTECTABLE_CODEC.test(c.mimeType))
-			: sendCodecs?.find((c) => c.mimeType.toLowerCase() === this.codec);
+		const preferredCodec = chooseSendCodec(sendCodecs, { e2ee: holdForE2ee, kind: clonedTrack?.kind, requested: this.codec });
 
 		const producer = await this.mediaService.sendTransport.produce({
 			...producerOptions,
@@ -359,7 +350,7 @@ export class MediaSender extends EventEmitter {
 		// The preference above normally settles this, but negotiation can still land somewhere the
 		// worker cannot protect. Refuse to send at all rather than emit a stream that would be either
 		// broken by the packetizer or, worse, readable by the media node.
-		if (holdForE2ee && !E2EE_PROTECTABLE_CODEC.test(codecMimeType ?? '')) {
+		if (holdForE2ee && !isProtectableCodec(codecMimeType)) {
 			logger.error('E2EE cannot protect the negotiated codec, not producing [codec:%s]', codecMimeType);
 			producer.close();
 

--- a/src/utils/mediaSender.tsx
+++ b/src/utils/mediaSender.tsx
@@ -10,6 +10,12 @@ import { Logger } from './Logger';
 
 const logger = new Logger('MediaSender');
 
+// Codecs the E2EE worker can split correctly. Opus and VP8/VP9 have a fixed or cheaply derived clear
+// header, so the SFU keeps what it needs for forwarding and the rest is encrypted. H264 does not: the
+// browser packetizes NAL units AFTER our transform has run, so encrypting past a fixed offset leaves
+// the packetizer walking ciphertext and the stream is broken rather than protected.
+const E2EE_PROTECTABLE_CODEC = /^(audio\/opus|video\/vp8|video\/vp9)$/i;
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export declare interface MediaSender {
 	// eslint-disable-next-line no-unused-vars
@@ -315,9 +321,17 @@ export class MediaSender extends EventEmitter {
 			track: clonedTrack
 		};
 
+		const sendCodecs = this.mediaService.sendRtpCapabilities?.codecs;
+
+		// With E2EE on, choose a codec the worker can protect instead of leaving it to negotiation,
+		// which is free to settle on H264. Without E2EE this keeps the previous behaviour exactly.
+		const preferredCodec = holdForE2ee && clonedTrack?.kind === 'video'
+			? sendCodecs?.find((c) => E2EE_PROTECTABLE_CODEC.test(c.mimeType))
+			: sendCodecs?.find((c) => c.mimeType.toLowerCase() === this.codec);
+
 		const producer = await this.mediaService.sendTransport.produce({
 			...producerOptions,
-			codec: this.mediaService.sendRtpCapabilities?.codecs?.find((c) => c.mimeType.toLowerCase() === this.codec)
+			codec: preferredCodec
 		});
 
 		const pauseListener = () => this.signalingService.notify('pauseProducer', { producerId: producer.id });
@@ -337,12 +351,22 @@ export class MediaSender extends EventEmitter {
 			throw new Error('Producer not needed');
 		}
 
-		this.producer = producer;
-
 		// E2EE: the codec comes from the negotiated producer, not this.codec. No start() call site
 		// supplies a codec, so this.codec is always undefined and would be read as Opus; the receive
 		// side reads this same field, so taking it from here keeps both transforms on one value.
 		const codecMimeType = producer.rtpParameters?.codecs?.[0]?.mimeType;
+
+		// The preference above normally settles this, but negotiation can still land somewhere the
+		// worker cannot protect. Refuse to send at all rather than emit a stream that would be either
+		// broken by the packetizer or, worse, readable by the media node.
+		if (holdForE2ee && !E2EE_PROTECTABLE_CODEC.test(codecMimeType ?? '')) {
+			logger.error('E2EE cannot protect the negotiated codec, not producing [codec:%s]', codecMimeType);
+			producer.close();
+
+			throw new Error(`E2EE cannot protect codec ${codecMimeType}`);
+		}
+
+		this.producer = producer;
 
 		// E2EE: attach the encrypt transform before any real media flows (no-op when E2EE is off).
 		if (holdForE2ee) {

--- a/src/utils/mediaSender.tsx
+++ b/src/utils/mediaSender.tsx
@@ -370,13 +370,18 @@ export class MediaSender extends EventEmitter {
 
 		// E2EE: attach the encrypt transform before any real media flows (no-op when E2EE is off).
 		if (holdForE2ee) {
-			await this.mediaService.e2eeService?.protectSender(producer.rtpSender, codecMimeType);
 			// Attaching is not enough: a browser can accept the transform and never feed it, which is
-			// how plaintext used to escape while the UI showed a shield. Hold the real track until the
-			// worker confirms it is processing frames. If that never happens the watchdog removes us
-			// from the room, so the track simply stays off rather than sending anything unprotected.
-			await this.mediaService.e2eeService?.whenProtectionActive();
-			if (clonedTrack) clonedTrack.enabled = true;
+			// how plaintext used to escape while the UI showed a shield. Hold the real track until
+			// THIS producer's own transform confirms it is processing frames. Waiting on a shared
+			// signal would release a second producer on the first one's confirmation.
+			const tid = await this.mediaService.e2eeService?.protectSender(producer.rtpSender, codecMimeType);
+			const protectedNow = await this.mediaService.e2eeService?.whenProtectionActive(tid);
+
+			if (!protectedNow) {
+				logger.error('E2EE never confirmed for this producer, leaving it silent [codec:%s]', codecMimeType);
+			} else if (clonedTrack) {
+				clonedTrack.enabled = true;
+			}
 		} else {
 			void this.mediaService.e2eeService?.protectSender(producer.rtpSender, codecMimeType);
 		}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: [ 'src/**/*.test.ts' ],
+	},
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -775,7 +775,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
+"@jridgewell/sourcemap-codec@npm:^1.5.5":
+  version: 1.6.0
+  resolution: "@jridgewell/sourcemap-codec@npm:1.6.0"
+  checksum: 10c0/b5be700e45a775f218589c3466c4ffea630582b4988657652da464e5ab8a7d18bf928ee4fd2363fb346ede4bea9c6ff0bae05a538358c4565ece6199531b5f72
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:0.3.31, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.28":
   version: 0.3.31
   resolution: "@jridgewell/trace-mapping@npm:0.3.31"
   dependencies:
@@ -1402,6 +1409,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
+  languageName: node
+  linkType: hard
+
 "@types/cookiejar@npm:^2.1.5":
   version: 2.1.5
   resolution: "@types/cookiejar@npm:2.1.5"
@@ -1415,6 +1432,13 @@ __metadata:
   dependencies:
     "@types/ms": "npm:*"
   checksum: 10c0/e5e124021bbdb23a82727eee0a726ae0fc8a3ae1f57253cbcc47497f259afb357de7f6941375e773e1abbfa1604c1555b901a409d762ec2bb4c1612131d4afb7
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
   languageName: node
   linkType: hard
 
@@ -1462,6 +1486,13 @@ __metadata:
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -1890,6 +1921,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/mocker@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@vitest/mocker@npm:5.0.0"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:0.3.31"
+    "@vitest/spy": "npm:5.0.0"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^1.2.3"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/b1dde0ef270e8f9401204cb19c798114de416c3cf31e1d44d0029c4281b33e9a799251e3015aaaa2bdf5858c97a56857812dcf1e04dcfd4ebeedf194e6bcf3e6
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:5.0.0":
+  version: 5.0.0
+  resolution: "@vitest/spy@npm:5.0.0"
+  checksum: 10c0/7521b4ef803bc89974a738cead7d3fcd789af805f3ea3f496108fc802b2bc09b22fe8e7a3cc0be3f92b647427aea528657e3e87dd0201e432f56e62f84f25ba8
+  languageName: node
+  linkType: hard
+
 "@webtorrent/http-node@npm:^1.3.0":
   version: 1.3.0
   resolution: "@webtorrent/http-node@npm:1.3.0"
@@ -2123,6 +2181,13 @@ __metadata:
     get-intrinsic: "npm:^1.2.6"
     is-array-buffer: "npm:^3.0.4"
   checksum: 10c0/2f2459caa06ae0f7f615003f9104b01f6435cc803e11bd2a655107d52a1781dc040532dc44d93026b694cc18793993246237423e13a5337e86b43ed604932c06
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
   languageName: node
   linkType: hard
 
@@ -2617,6 +2682,13 @@ __metadata:
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.3"
   checksum: 10c0/c0b8b4a093964270c014ac93b5af2c2c452974737c2c1dc988821fe9cc8fd9d6a85f7380c477cb881e057f144a7aa50e743b836a47a69c94e18a4a21277b25d5
+  languageName: node
+  linkType: hard
+
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
   languageName: node
   linkType: hard
 
@@ -3132,6 +3204,7 @@ __metadata:
     vite: "npm:^8.2.0"
     vite-plugin-eslint: "npm:^1.8.1"
     vite-tsconfig-paths: "npm:^6.1.1"
+    vitest: "npm:^5.0.0"
     webtorrent: "npm:^3.0.21"
   dependenciesMeta:
     node-datachannel@0.32.2:
@@ -3310,6 +3383,13 @@ __metadata:
     math-intrinsics: "npm:^1.1.0"
     safe-array-concat: "npm:^1.1.3"
   checksum: 10c0/39837bb23bf6e53a066ae6a218c62bbc2c3cdd7da19336104bd7a16521675fcd9a61abe9cecf37992616584bee1d72f057bac66f2115fcf4840c934df6e96689
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "es-module-lexer@npm:2.3.2"
+  checksum: 10c0/5e7389424c43478439f12f9a6aca1750f6f99afa384fc3de329f4a45f152ab156671055008adaafc74960877abf8cc338aeebf6bed8c21297b146fd6eb7a22f8
   languageName: node
   linkType: hard
 
@@ -3587,6 +3667,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
@@ -3645,6 +3734,13 @@ __metadata:
   version: 2.0.3
   resolution: "expand-template@npm:2.0.3"
   checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10c0/d40d76b8570695d36587beb3cc28494da2ca3ec8f04e67f5622ed2d372d850e401a9adef19c6835e1a8173903f157c79540b34c7b3fbd7cd8ce726cc903c57b7
   languageName: node
   linkType: hard
 
@@ -5239,6 +5335,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^1.2.3":
+  version: 1.2.3
+  resolution: "magic-string@npm:1.2.3"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/541ecb30ec96e4d9b76ca65aed00124592dca26739aeee86e01d7fbce227b3fce43c9d2f0b9495dc9077c30794c967b1e091445614e2e45722ea4c128be60a93
+  languageName: node
+  linkType: hard
+
 "magnet-uri@npm:^7.0.10":
   version: 7.0.10
   resolution: "magnet-uri@npm:7.0.10"
@@ -5784,6 +5889,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10c0/34a0ee97cd88573cfd97d384c2a79f07118ae5680d7e45d1de6e99c74eddefe145e8ca27a2db02195a1ee5fded5aa22b924869c842728c201b9f109a27d0ef19
+  languageName: node
+  linkType: hard
+
 "once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -5999,6 +6111,13 @@ __metadata:
   version: 4.0.5
   resolution: "picomatch@npm:4.0.5"
   checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.7":
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10c0/beb6ae02c43ae44e84883b90830196d9046b1726ead292adcf7f57945e0bb0d992d68563d87e03b484b6f3c9a5c6defda7523477f047d7f0e663f126cc01787f
   languageName: node
   linkType: hard
 
@@ -6913,6 +7032,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -7034,6 +7160,20 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/cf6408a18676c57ff2ed06b8a20dc64bb3e748e5c7e095332e6aecaa2b8422b1e94a739a8453bf65156a8a47afe23757ba4ab52d3ea3b62322dc40875763e17a
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10c0/40ac525ce7b7c556abc332a7376f14356eeb1a7f17f6ff9a003eb9f52326ff1f3745d3e1b43452675b1ec6fcc319f1b1d6f3b0d386cf3f91058479ad883cff69
   languageName: node
   linkType: hard
 
@@ -7334,6 +7474,20 @@ __metadata:
   version: 1.0.3
   resolution: "timeout-refresh@npm:1.0.3"
   checksum: 10c0/a808f0f5c45c315c9574262a3428c8c556b5d676ccdc64c8759028e2e98e3f49c469320b942cac6e1a2d209aecc05c03a1b2de2748768617cfe505215dbba5ec
+  languageName: node
+  linkType: hard
+
+"tinybench@npm:6.1.4":
+  version: 6.1.4
+  resolution: "tinybench@npm:6.1.4"
+  checksum: 10c0/7a815318a02270a98247298ddd289b75c841725606c977f0b74749bc5ec811a44998267ccb60bd3deb23b551dbfaf4d979eb08e9b04fbc87ff571f9b39cc61c3
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:1.3.0":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10c0/e9b89f97489d2aab2cef408da279e6b32547e738d1275032ccb8fd0028a006d93eb70fc51c6cffd9fc2f5aca6c2a273d8b6f73b52d46ee5116da6b94969ef958
   languageName: node
   linkType: hard
 
@@ -7789,6 +7943,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "vitest@npm:5.0.0"
+  dependencies:
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/mocker": "npm:5.0.0"
+    chai: "npm:^6.2.2"
+    es-module-lexer: "npm:^2.3.2"
+    expect-type: "npm:^1.4.0"
+    magic-string: "npm:^1.2.3"
+    obug: "npm:^2.1.4"
+    picomatch: "npm:^4.0.7"
+    std-env: "npm:^4.2.0"
+    tinybench: "npm:6.1.4"
+    tinyexec: "npm:1.3.0"
+    tinyglobby: "npm:^0.2.17"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 5.0.0
+    "@vitest/browser-preview": 5.0.0
+    "@vitest/browser-webdriverio": ^5.0.0-beta.5 || >=5.0.0
+    "@vitest/coverage-istanbul": 5.0.0
+    "@vitest/coverage-v8": 5.0.0
+    "@vitest/ui": 5.0.0
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.4.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: ./vitest.mjs
+  checksum: 10c0/de56a0f2e989949e42cdf31150ef5c0c138c04950d14b158f618f8bd4dc9b7f1e9a20c98a2763c9fef0d2b5a97d86456a73dd18ebb8b2b99dd0837efd8688634
+  languageName: node
+  linkType: hard
+
 "w3c-xmlserializer@npm:^5.0.0":
   version: 5.0.0
   resolution: "w3c-xmlserializer@npm:5.0.0"
@@ -7994,6 +8209,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## E2EE: fail-closed fixes, free key advance on arrival, cheaper departures, tests

Follow-up to the E2EE proof of concept merged on 31 August. Thirteen commits, twenty files,
client only. Behaviour in rooms without encryption is unchanged and was re-verified on this build.

### Why

The first version replaced every participant's key on every membership change: N² messages and
a keyframe from every camera per join or leave, and ~2.7 million messages to fill a 200-person
room. Review and browser testing also turned up a fail-open path and a few places where the
implementation was weaker than the badge claimed. This branch fixes those and brings the cost
of membership changes down to the point where a lecture is workable.

### Security and correctness fixes (from review)

- Frames of a length no sender could produce are dropped instead of passed to the decoder.
- A producer whose negotiated codec the worker cannot protect (H264) is closed rather than sent
  unprotected; a protectable codec is preferred at negotiation time.
- Each producer waits for its own transform to confirm before its track is released; a missing
  transform now reads as failure, not success.
- Decrypt keys are evicted per sender instead of kept forever (replay window bounded).

### Key handling

- **Arrival:** each present participant advances its key through HKDF and sends only the
  newcomer the result. Existing receivers derive the new key from the first frame that carries it.
  No signalling to existing peers, no keyframe. Arrivals are batched over 200 ms.
- A newcomer's reply announcement inside that window is not treated as a key request
  (it previously received the pre-advance key, found in a live log).
- A participant that has encrypted nothing under its current key does not advance
  (nothing to hide, and it keeps muted participants from drifting).
- **Departure:** keys are replaced with fresh material, but only by participants that have a
  producer; the rest mark the key burned and replace it when their next producer starts, before
  its transform attaches. Departures are batched over 200 ms.
- **Recovery:** a receiver that cannot decrypt a sender for ~3 s re-announces its identity to that
  sender, which answers with its current key. No new signalling method; rate limited both ways.
- Key changes are serialized in the provider, and a wrap snapshots key and id together
  (two pre-existing races that could pair the wrong bytes with an epoch).
- A derived key that fails to authenticate is not re-derived per frame (this held up the Firefox
  decrypt worker for seconds during departures).

### Tests

Vitest added to the client: 7 files, 119 tests (crypto, frame sealing/parsing, key store,
provider, codec choice, service with a faked worker, middleware with faked signalling).
Room-server relay tests (5) are already on that repo's main.

### Verified in browsers

Chrome, Edge, Firefox 154/155, all decrypt directions; arrivals; the muted-peer gate;
departures incl. batching and the burned-key path; screen share; receive-only join; late media;
recovery; short and long reconnect; and an E2EE-off room on the same build.

### Notes for review

- `mediaSender.tsx` is the only file on the shared media path touched: the codec decision moved
  to `utils/e2ee/codecChoice.ts` with identical off-path behaviour, covered by tests.
- `vitest` added as a devDependency (`yarn test`).
- `E2EE.md` in the edumeet repo is rewritten to match and lands right after this.

